### PR TITLE
fix: make formatCurrency more resilient

### DIFF
--- a/src/currencies/getCurrencyFormatting.ts
+++ b/src/currencies/getCurrencyFormatting.ts
@@ -39,7 +39,7 @@ export function getCurrencyFormatting(overrides: Partial<CurrencyConfig> = {}) {
   }
   if (!overrides.currencySettings) {
     nostojs(api => {
-      config.currencySettings = api.internal.getSettings().currencySettings
+      config.currencySettings = api.internal.getSettings().currencySettings ?? {}
     })
   }
 

--- a/test/currencies/getCurrencyFormatting.spec.ts
+++ b/test/currencies/getCurrencyFormatting.spec.ts
@@ -86,4 +86,15 @@ describe("currency formatting", () => {
     getCurrencyFormatting()
     expect(mockApi.internal.getSettings).toHaveBeenCalledTimes(1)
   })
+
+  it("should not crash if currencySettings is not provided", async () => {
+    const mockApi = {
+      internal: {
+        getSettings: vi.fn(() => ({}))
+      }
+    }
+    mockNostojs(mockApi)
+
+    expect(() => getCurrencyFormatting().formatCurrency(12345.0)).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Function should use fallback instead of crashing if currency settings are not provided

