### PR TITLE
Add support for main image thumbs without hash

### DIFF
--- a/src/thumbnails/generateThumbnailUrl.ts
+++ b/src/thumbnails/generateThumbnailUrl.ts
@@ -5,7 +5,7 @@ export type Props = {
   // Also known as imageVersion
   size: ThumbnailSize
   productId: string
-  hash: string
+  hash?: string
 }
 
 /**
@@ -16,5 +16,6 @@ export function generateThumbnailUrl({ size, productId, hash }: Props) {
   if (!settings) {
     throw new Error("Client script settings are not yet available")
   }
-  return `https://${settings.thumbnailHost}/${settings.account}/${size}/${productId}/${hash}/A`
+  const baseUrl = `https://${settings.thumbnailHost}/${settings.account}/${size}/${productId}`
+  return hash ? `${baseUrl}/${hash}/A` : baseUrl
 }

--- a/src/thumbnails/thumbnailDecorator.ts
+++ b/src/thumbnails/thumbnailDecorator.ts
@@ -4,14 +4,15 @@ import { ThumbnailSize } from "./types"
 
 export type Config = {
   size: ThumbnailSize
+  requireHash?: boolean
 }
 
 /**
  * Replaces full size images with thumbnail sized versions.
  */
-export function thumbnailDecorator({ size }: Config) {
-  function getThumbnailUrlForHash(productId: string, hash: string | undefined) {
-    if (!hash) {
+export function thumbnailDecorator({ size, requireHash = false }: Config) {
+  function getThumbnailUrlForHash(productId: string, hash: string | undefined, requireHash = true) {
+    if (!hash && requireHash) {
       return undefined
     }
 
@@ -57,7 +58,7 @@ export function thumbnailDecorator({ size }: Config) {
 
     return {
       ...hit,
-      imageUrl: getThumbnailUrlForHash(productId, hit.imageHash) ?? hit.imageUrl,
+      imageUrl: getThumbnailUrlForHash(productId, hit.imageHash, requireHash) ?? hit.imageUrl,
       thumbUrl: getThumbnailUrlForHash(productId, hit.thumbHash) ?? hit.thumbUrl,
       skus: processSkus(productId, hit.skus),
       alternateImageUrls: processAlternateImages(productId, hit.alternateImageUrls, hit.alternateImageHashes)

--- a/test/thumbnails/generateThumbnailUrl.spec.ts
+++ b/test/thumbnails/generateThumbnailUrl.spec.ts
@@ -3,16 +3,25 @@ import { generateThumbnailUrl } from "../../src/thumbnails/generateThumbnailUrl"
 import { mockSettings } from "@nosto/nosto-js/testing"
 
 describe("generateThumbnailUrl", () => {
+  mockSettings({
+    account: "1111",
+    thumbnailHost: "thumbs.nosto.com"
+  })
+
   it("should generate the correct URL", () => {
-    mockSettings({
-      account: "1111",
-      thumbnailHost: "thumbs.nosto.com"
-    })
     const url = generateThumbnailUrl({
       size: "2",
       productId: "2222",
       hash: "3333"
     })
     expect(url).toEqual("https://thumbs.nosto.com/1111/2/2222/3333/A")
+  })
+
+  it("should also support usage without a hash", () => {
+    const url = generateThumbnailUrl({
+      size: "2",
+      productId: "2222"
+    })
+    expect(url).toEqual("https://thumbs.nosto.com/1111/2/2222")
   })
 })

--- a/test/thumbnails/thumbnailDecorator.spec.ts
+++ b/test/thumbnails/thumbnailDecorator.spec.ts
@@ -65,9 +65,10 @@ describe("thumbnailDecorator", () => {
     expect(result).toEqual(mockProduct)
   })
 
-  it("should not modify imageUrl if imageHash is not provided", () => {
+  it("should not modify imageUrl if imageHash is not provided and requireHash is enabled", () => {
     const decorator = thumbnailDecorator({
-      size: "13"
+      size: "13",
+      requireHash: true
     })
 
     const mockProduct: SearchProduct = {
@@ -80,9 +81,26 @@ describe("thumbnailDecorator", () => {
     expect(result).toEqual(mockProduct)
   })
 
+  it("should modify imageUrl is imageHash is not provided and requireHash is disabled", () => {
+    const decorator = thumbnailDecorator({
+      size: "13",
+      requireHash: false // default
+    })
+
+    const mockProduct: SearchProduct = {
+      productId: "productId",
+      imageUrl: "oldUrl",
+      imageHash: undefined
+    }
+
+    const result = decorator(mockProduct)
+    expect(result.imageUrl).toEqual("https://thumbs.nosto.com/accountId/13/productId")
+  })
+
   it("should not modify thumbUrl if thumbHash is not provided", () => {
     const decorator = thumbnailDecorator({
-      size: "13"
+      size: "13",
+      requireHash: true
     })
 
     const mockProduct: SearchProduct = {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Add support for main image thumbnail when hash key is missing

Example of main image based on hash 
https://thumbs.nosto.com/shopify-9758212174/8/6871545675854/d5e96059bfdb07ffe1b17e658cb2e7c68cb6e646b22d5af311d5bf2a03de5998/A

Cache Control: max-age=31536000, public

and same image without hash
https://thumbs.nosto.com/shopify-9758212174/8/6871545675854

Cache Control: max-age=3600, public

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
