### PR TITLE
Use shopify decorator for Shopify merchants

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The main export of this library is the `search` function. It is compatible with 
 ```ts
 import { search } from "@nosto/search-js"
 import { priceDecorator } from "@nosto/search-js/currencies"
+import { thumbnailDecorator } from "@nosto/search-js/thumbnails"
 
 const response = await search({
     query: 'my search',
@@ -41,13 +42,16 @@ const response = await search({
             "name",
             "price",
             "listPrice",
-            "priceCurrencyCode"
+            "priceCurrencyCode",
+            "imageUrl",
+            "imageHash"
         ] 
     }
 }, {
     track: 'serp',
     hitDecorators: [
-        priceDecorator()
+        priceDecorator(),
+        thumbnailDecorator()
     ]
 })
 

--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  Nosto?: { shopifyScript?: boolean }
+}

--- a/src/thumbnails.ts
+++ b/src/thumbnails.ts
@@ -1,6 +1,6 @@
 /** @module thumbnails */
 /* eslint-disable barrel-files/avoid-barrel-files */
 export { generateThumbnailUrl, type Props } from "./thumbnails/generateThumbnailUrl"
-export { thumbnailDecorator, type Config } from "./thumbnails/thumbnailDecorator"
+export { thumbnailDecorator, nostoThumbnailDecorator, type Config } from "./thumbnails/thumbnailDecorator"
 export { shopifyThumbnailDecorator, type Config as ShopifyConfig } from "./thumbnails/shopifyThumbnailDecorator"
 export type { ThumbnailSize, ShopifySize } from "./thumbnails/types"

--- a/test/thumbnails/thumbnailDecorator.spec.ts
+++ b/test/thumbnails/thumbnailDecorator.spec.ts
@@ -9,6 +9,8 @@ describe("thumbnailDecorator", () => {
       account: "accountId",
       thumbnailHost: "thumbs.nosto.com"
     })
+    // @ts-expect-error not defined
+    window.Nosto = {}
   })
   it("should replace the product image url", () => {
     const decorator = thumbnailDecorator({
@@ -48,6 +50,37 @@ describe("thumbnailDecorator", () => {
       imageUrl: "oldUrl"
     })
     expect(result.imageUrl).toEqual("https://thumbs.nosto.com/accountId/13/productId/imageHash/A")
+  })
+
+  it("should use the Shopify decorator for Shopify merchants", () => {
+    // @ts-expect-error not defined
+    window.Nosto = { shopifyScript: true }
+    const decorator = thumbnailDecorator({ size: "7" })
+
+    const shopifyUrl = "https://cdn.shopify.com/s/files/1/0097/5821/2174/files/clothing-red.jpg?v=12345"
+    const modifiedUrl =
+      "https://cdn.shopify.com/s/files/1/0097/5821/2174/files/clothing-red_200x200_crop_center.jpg?v=12345"
+
+    const result = decorator({
+      imageUrl: shopifyUrl
+    })
+
+    expect(result.imageUrl).toEqual(modifiedUrl)
+  })
+
+  it("should fallback to hash based thumbnails for Shopify merchants without Shopify CDN images", () => {
+    // @ts-expect-error not defined
+    window.Nosto = { shopifyScript: true }
+    const decorator = thumbnailDecorator({
+      size: "9"
+    })
+
+    const result = decorator({
+      productId: "productId",
+      imageHash: "imageHash",
+      imageUrl: "http://acme.cdn.com/products/productId.jpg"
+    })
+    expect(result.imageUrl).toEqual("https://thumbs.nosto.com/accountId/9/productId/imageHash/A")
   })
 
   it("should not modify object if productId is not provided", () => {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Modifies the main thumbnail decorator to use shopify CDN thumbnails for Shopify merchants
Splits the thumbnail decorators into
* thumbnailDecorator - uses Nosto & Shopify CDN thumbnails based on platform and image url
* nostoThumbnailDecorator - image hash based Nosto CDN thumbnails
* shopifyThumbnailDecorator - Shopify CDN thumbnails

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
