### PR TITLE
Add path aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "Nosto",
   "scripts": {
     "build": "tsc && vite build && npm run build-dts && npm run typedoc",
-    "build-dts": "tsc --noEmit false --emitDeclarationOnly",
+    "build-dts": "tsc --project tsconfig.build.json",
     "typedoc": "typedoc",
     "test": "vitest --run",
     "test:watch": "vitest",

--- a/packages/core/test/search.shouldRetry.spec.ts
+++ b/packages/core/test/search.shouldRetry.spec.ts
@@ -1,6 +1,5 @@
+import { shouldRetry } from "@core/searchWithRetries"
 import { describe, expect, it } from "vitest"
-
-import { shouldRetry } from "../src/searchWithRetries"
 
 describe("shouldRetry", () => {
   it("should return true for an error without status", () => {

--- a/packages/core/test/search.spec.ts
+++ b/packages/core/test/search.spec.ts
@@ -1,9 +1,8 @@
+import { search } from "@core/search"
+import type { HitDecorator } from "@core/types"
 import { SearchProduct, SearchQuery } from "@nosto/nosto-js/client"
 import { mockNostojs } from "@nosto/nosto-js/testing"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-
-import { search } from "../src/search"
-import { HitDecorator } from "../src/types"
 
 describe("search", () => {
   beforeEach(() => {

--- a/packages/currencies/test/getCurrencyFormatting.spec.ts
+++ b/packages/currencies/test/getCurrencyFormatting.spec.ts
@@ -1,7 +1,6 @@
+import { getCurrencyFormatting } from "@currencies/getCurrencyFormatting"
 import { mockNostojs } from "@nosto/nosto-js/testing"
 import { describe, expect, it, vi } from "vitest"
-
-import { getCurrencyFormatting } from "../currencies"
 
 const currencyFormatsMock = {
   GBP: {

--- a/packages/currencies/test/priceDecorator.spec.ts
+++ b/packages/currencies/test/priceDecorator.spec.ts
@@ -1,8 +1,7 @@
+import { priceDecorator } from "@currencies/priceDecorator"
 import { SearchProduct } from "@nosto/nosto-js/client"
 import { mockNostojs } from "@nosto/nosto-js/testing"
 import { describe, expect, it } from "vitest"
-
-import { priceDecorator } from "../src/priceDecorator"
 
 mockNostojs({
   internal: {

--- a/packages/preact/test/hooks/usePersonalization.spec.ts
+++ b/packages/preact/test/hooks/usePersonalization.spec.ts
@@ -1,9 +1,8 @@
 import { nostojs } from "@nosto/nosto-js"
 import { clearNostoGlobals, mockNostojs } from "@nosto/nosto-js/testing"
+import { usePersonalization } from "@preact/hooks/usePersonalization"
 import { renderHook } from "@testing-library/preact"
 import { afterEach, describe, expect, it } from "vitest"
-
-import { usePersonalization } from "../../src/hooks/usePersonalization"
 
 describe("usePersonalization", () => {
   afterEach(() => {

--- a/packages/thumbnails/test/generateThumbnailUrl.spec.ts
+++ b/packages/thumbnails/test/generateThumbnailUrl.spec.ts
@@ -1,7 +1,6 @@
 import { mockSettings } from "@nosto/nosto-js/testing"
+import { generateThumbnailUrl } from "@thumbnails/generateThumbnailUrl"
 import { describe, expect, it } from "vitest"
-
-import { generateThumbnailUrl } from "../src/generateThumbnailUrl"
 
 describe("generateThumbnailUrl", () => {
   it("should generate the correct URL", () => {

--- a/packages/thumbnails/test/shopifyThumbnailDecorator.spec.ts
+++ b/packages/thumbnails/test/shopifyThumbnailDecorator.spec.ts
@@ -1,6 +1,5 @@
+import { shopifyThumbnailDecorator } from "@thumbnails/shopifyThumbnailDecorator"
 import { describe, expect, it } from "vitest"
-
-import { shopifyThumbnailDecorator } from "../src/shopifyThumbnailDecorator"
 
 describe("shopifyThumbnailDecorator", () => {
   it("keeps non-shopify URLs as is", () => {

--- a/packages/thumbnails/test/thumbnailDecorator.spec.ts
+++ b/packages/thumbnails/test/thumbnailDecorator.spec.ts
@@ -1,8 +1,7 @@
 import { SearchProduct } from "@nosto/nosto-js/client"
 import { mockSettings } from "@nosto/nosto-js/testing"
+import { thumbnailDecorator } from "@thumbnails/thumbnailDecorator"
 import { beforeEach, describe, expect, it } from "vitest"
-
-import { thumbnailDecorator } from "../src/thumbnailDecorator"
 
 describe("thumbnailDecorator", () => {
   beforeEach(() => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "packages",
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+  },
+  "exclude": ["dist", "**/vite.config.ts", "**/test"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "declaration": true,
-    "rootDir": "packages",
     "outDir": "dist",
 
     /* Bundler mode */
@@ -21,9 +20,18 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
+    /* JSX */
     "jsx": "react",
     "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment"
-  },
-  "exclude": ["dist", "**/vite.config.ts", "**/test"]
+    "jsxFragmentFactory": "Fragment",
+
+    /* Alias */
+    "baseUrl": ".",
+    "paths": {
+      "@core/*": ["packages/core/src/*"],
+      "@currencies/*": ["packages/currencies/src/*"],
+      "@preact/*": ["packages/preact/src/*"],
+      "@thumbnails/*": ["packages/thumbnails/src/*"]
+    }
+  }  
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,14 @@ export const baseConfig = {
       external: ["preact", "preact/hooks"]
     }
   },
+  resolve: {
+    alias: {
+      "@core": resolve(import.meta.dirname, "packages/core/src"),
+      "@currencies": resolve(import.meta.dirname, "packages/currencies/src"),
+      "@preact": resolve(import.meta.dirname, "packages/preact/src"),
+      "@thumbnails": resolve(import.meta.dirname, "packages/thumbnails/src")
+    }
+  },
   test: {
     globals: true,
     environment: "jsdom"


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Adds support for path aliases (`@core`, `@currencies`, `@preact`, `@thumbnails`) for internal packages. Preparation for sources extraction.

The PR is based on top of https://github.com/Nosto/search-js/pull/70 .

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-797
