### PR TITLE
feat: move state management from library

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,22 +18,22 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/core/index.d.ts",
+      "types": "./dist/core/core.d.ts",
       "import": "./dist/core/core.es.js",
       "require": "./dist/core/core.cjs.js"
     },
     "./currencies": {
-      "types": "./dist/currencies/index.d.ts",
+      "types": "./dist/currencies/currencies.d.ts",
       "import": "./dist/currencies/currencies.es.js",
       "require": "./dist/currencies/currencies.cjs.js"
     },
     "./thumbnails": {
-      "types": "./dist/thumbnails/index.d.ts",
+      "types": "./dist/thumbnails/thumbnails.d.ts",
       "import": "./dist/thumbnails/thumbnails.es.js",
       "require": "./dist/thumbnails/thumbnails.cjs.js"
     },
     "./preact": {
-      "types": "./dist/preact/index.d.ts",
+      "types": "./dist/preact/preact.d.ts",
       "import": "./dist/preact/preact.es.js",
       "require": "./dist/preact/preact.cjs.js"
     }

--- a/packages/preact/preact.ts
+++ b/packages/preact/preact.ts
@@ -1,2 +1,6 @@
 /** @module preact */
+export { useNostoState } from "./src/hooks/useNostoState"
 export { usePersonalization } from "./src/hooks/usePersonalization"
+export { type State, type Store } from "./src/store"
+export { StoreContext, StoreProvider } from "./src/storeContext"
+export { mockStore } from "./test/mocks/mocks"

--- a/packages/preact/preact.ts
+++ b/packages/preact/preact.ts
@@ -1,5 +1,5 @@
 /** @module preact */
-export { useNostoState } from "./src/hooks/useNostoState"
+export { useNostoAppState } from "./src/hooks/useNostoAppState"
 export { usePersonalization } from "./src/hooks/usePersonalization"
 export { type State, type Store } from "./src/store"
 export { StoreContext, StoreProvider } from "./src/storeContext"

--- a/packages/preact/src/hooks/useNostoAppState.ts
+++ b/packages/preact/src/hooks/useNostoAppState.ts
@@ -7,14 +7,14 @@ import { useContext, useEffect, useState } from "preact/hooks"
  *
  * @example
  * ```jsx
- * import { useNostoState } from '@nosto/search-js/preact'
+ * import { useNostoAppState } from '@nosto/search-js/preact'
  *
  * export default () => {
- *     const pageType = useNostoState(state => state.pageType)
+ *     const pageType = useNostoAppState(state => state.pageType)
  *
  *     return (
  *       <div>
- *         Page type is {pageTypey}
+ *         Page type is {pageType}
  *       </div>
  *     )
  * }
@@ -25,10 +25,10 @@ import { useContext, useEffect, useState } from "preact/hooks"
  *
  * @example
  * ```jsx
- * import { useNostoState } from '@nosto/search-js/preact'
+ * import { useNostoAppState } from '@nosto/search-js/preact'
  *
  * export default () => {
- *     const state = useNostoState()
+ *     const state = useNostoAppState()
  *
  *     return (
  *       <div>
@@ -40,7 +40,7 @@ import { useContext, useEffect, useState } from "preact/hooks"
  *
  * @group Hooks
  */
-export function useNostoState<Selected>(selector: (state: State) => Selected = fullStateSelector<Selected>): Selected {
+export function useNostoAppState<Selected>(selector: (state: State) => Selected = fullStateSelector<Selected>) {
   const store = useContext(StoreContext)
   const [slice, setSlice] = useState(selector(store.getState()))
   store.onChange(selector, setSlice)

--- a/packages/preact/src/hooks/useNostoState.ts
+++ b/packages/preact/src/hooks/useNostoState.ts
@@ -1,0 +1,53 @@
+import { State } from "@preact/store"
+import { StoreContext } from "@preact/storeContext"
+import { useContext, useEffect, useState } from "preact/hooks"
+
+/**
+ * Imports a part of the Nosto state to the component.
+ *
+ * @example
+ * ```jsx
+ * import { useNostoState } from '@nosto/search-js/preact'
+ *
+ * export default () => {
+ *     const pageType = useNostoState(state => state.pageType)
+ *
+ *     return (
+ *       <div>
+ *         Page type is {pageTypey}
+ *       </div>
+ *     )
+ * }
+ * ```
+ *
+ * If the selector parameter is not provided, the full state is returned.
+ * Be mindful of the unnecessary rerenders it may cause.
+ *
+ * @example
+ * ```jsx
+ * import { useNostoState } from '@nosto/search-js/preact'
+ *
+ * export default () => {
+ *     const state = useNostoState()
+ *
+ *     return (
+ *       <div>
+ *         Page type is {state.pageType}
+ *       </div>
+ *     )
+ * }
+ * ```
+ *
+ * @group Hooks
+ */
+export function useNostoState<Selected>(selector: (state: State) => Selected = fullStateSelector<Selected>): Selected {
+  const store = useContext(StoreContext)
+  const [slice, setSlice] = useState(selector(store.getState()))
+  store.onChange(selector, setSlice)
+  useEffect(() => {
+    return () => store.clearOnChange(setSlice)
+  }, [store])
+  return slice
+}
+
+const fullStateSelector = <Selected>(state: State) => state as Selected

--- a/packages/preact/src/store.tsx
+++ b/packages/preact/src/store.tsx
@@ -1,0 +1,106 @@
+import type { SearchPageType, SearchQuery, SearchResult } from "@nosto/nosto-js/client"
+import { deepFreeze } from "@utils/deepFreeze"
+import { deepMerge } from "@utils/deepMerge"
+import { isEqual } from "@utils/isEqual"
+
+/**
+ * Preact state includes all changing variables of the app.
+ * After each change page is automatically rerendered.
+ * State includes user input, output and other useful things.
+ */
+export interface State {
+  /**
+   * Indicates that the search is loading, loader should be shown when `true`.
+   */
+  loading: boolean
+  /**
+   * Current search query that includes all user input like search text, filters, sort, page, etc.
+   */
+  query: SearchQuery
+  /**
+   * Displays which page type it is - category | search
+   */
+  pageType: SearchPageType | undefined
+  /**
+   * Current search response that includes found products, keywords and other results.
+   */
+  response: SearchResult
+  /**
+   * Indicates that preact app is initialized.
+   */
+  initialized: boolean
+  /**
+   * Custom params from URL
+   */
+  customParams: Record<string, unknown>
+  /**
+   * History items
+   */
+  historyItems?: string[]
+}
+
+export const defaultState: State = {
+  loading: true,
+  pageType: undefined,
+  query: {
+    query: ""
+  },
+  response: {
+    query: ""
+  },
+  initialized: false,
+  customParams: {}
+}
+
+export function createStore(overrides: Partial<State>) {
+  const changeCallbacks: Map<(piece: never) => void, (state: State) => void> = new Map()
+  let state: State = overrides ? deepMerge(defaultState, overrides) : defaultState
+  const initialState = deepFreeze(state)
+
+  function setState(newState: (prevState: State) => State) {
+    state = newState(state)
+    for (const callback of changeCallbacks.values()) {
+      callback(state)
+    }
+  }
+
+  function updateState(newState: Partial<State>) {
+    setState(prevState => {
+      return { ...prevState, ...newState }
+    })
+  }
+
+  function getState() {
+    return state
+  }
+
+  function getInitialState() {
+    return initialState
+  }
+
+  function onChange<T>(selector: (state: State) => T, callback: (piece: T) => void) {
+    let lastValue: T | undefined
+
+    changeCallbacks.set(callback, newState => {
+      const piece = selector(newState)
+      if (!isEqual(piece, lastValue)) {
+        lastValue = piece
+        callback(piece)
+      }
+    })
+  }
+
+  function clearOnChange<T>(callback: (piece: T) => void) {
+    changeCallbacks.delete(callback)
+  }
+
+  return {
+    updateState,
+    getState,
+    getInitialState,
+    onChange,
+    clearOnChange
+  }
+}
+
+export type Store = ReturnType<typeof createStore>

--- a/packages/preact/src/storeContext.tsx
+++ b/packages/preact/src/storeContext.tsx
@@ -1,0 +1,14 @@
+import { ComponentChildren, createContext } from "preact"
+
+import { createStore, Store } from "./store"
+
+export const StoreContext = createContext<Store>(createStore({}))
+
+type Props = {
+  store: Store
+  children: ComponentChildren
+}
+
+export function StoreProvider({ store, children }: Props) {
+  return <StoreContext value={store}>{children}</StoreContext>
+}

--- a/packages/preact/test/hooks/useNostoAppState.spec.tsx
+++ b/packages/preact/test/hooks/useNostoAppState.spec.tsx
@@ -1,10 +1,10 @@
-import { useNostoState } from "@preact/hooks/useNostoState"
+import { useNostoAppState } from "@preact/hooks/useNostoAppState"
 import { describe, expect, it, vi } from "vitest"
 
 import { mockStore } from "../mocks/mocks"
 import { renderHookWithProviders } from "../mocks/renderHookWithProviders"
 
-describe("useNostoState", () => {
+describe("useNostoAppState", () => {
   const store = mockStore({
     loading: false,
     initialized: true,
@@ -19,24 +19,24 @@ describe("useNostoState", () => {
   })
 
   it("returns the entire state when selected", () => {
-    const render = renderHookWithProviders(() => useNostoState(state => state), { store })
+    const render = renderHookWithProviders(() => useNostoAppState(state => state), { store })
 
     expect(render.result.current).toEqual(store.getInitialState())
   })
 
   it("returns response from state when selected", () => {
-    const render = renderHookWithProviders(() => useNostoState(state => state.response), { store })
+    const render = renderHookWithProviders(() => useNostoAppState(state => state.response), { store })
 
     expect(render.result.current).toEqual(store.getState().response)
   })
 
   it("does not modify the store state", () => {
-    renderHookWithProviders(() => useNostoState(state => state.response), { store })
+    renderHookWithProviders(() => useNostoAppState(state => state.response), { store })
     expect(store.getState()).toEqual(store.getInitialState())
   })
 
   it("updates the selector when state changes", () => {
-    const render = renderHookWithProviders(() => useNostoState(state => state.loading), { store })
+    const render = renderHookWithProviders(() => useNostoAppState(state => state.loading), { store })
 
     expect(render.result.current).toEqual(false)
     store.updateState({
@@ -50,14 +50,14 @@ describe("useNostoState", () => {
     store.onChange = vi.fn()
     store.clearOnChange = vi.fn()
 
-    renderHookWithProviders(() => useNostoState(state => state.loading), { store })
+    renderHookWithProviders(() => useNostoAppState(state => state.loading), { store })
 
     expect(store.onChange).toHaveBeenCalled()
     expect(store.clearOnChange).not.toHaveBeenCalled()
   })
 
   it("clears out the store registration on unmount", () => {
-    const render = renderHookWithProviders(() => useNostoState(state => state.loading), { store })
+    const render = renderHookWithProviders(() => useNostoAppState(state => state.loading), { store })
 
     store.clearOnChange = vi.fn()
     render.unmount()

--- a/packages/preact/test/hooks/useNostoState.spec.tsx
+++ b/packages/preact/test/hooks/useNostoState.spec.tsx
@@ -1,0 +1,67 @@
+import { useNostoState } from "@preact/hooks/useNostoState"
+import { describe, expect, it, vi } from "vitest"
+
+import { mockStore } from "../mocks/mocks"
+import { renderHookWithProviders } from "../mocks/renderHookWithProviders"
+
+describe("useNostoState", () => {
+  const store = mockStore({
+    loading: false,
+    initialized: true,
+    response: {
+      query: "I'm a query",
+      products: {
+        size: 10,
+        total: 100,
+        hits: []
+      }
+    }
+  })
+
+  it("returns the entire state when selected", () => {
+    const render = renderHookWithProviders(() => useNostoState(state => state), { store })
+
+    expect(render.result.current).toEqual(store.getInitialState())
+  })
+
+  it("returns response from state when selected", () => {
+    const render = renderHookWithProviders(() => useNostoState(state => state.response), { store })
+
+    expect(render.result.current).toEqual(store.getState().response)
+  })
+
+  it("does not modify the store state", () => {
+    renderHookWithProviders(() => useNostoState(state => state.response), { store })
+    expect(store.getState()).toEqual(store.getInitialState())
+  })
+
+  it("updates the selector when state changes", () => {
+    const render = renderHookWithProviders(() => useNostoState(state => state.loading), { store })
+
+    expect(render.result.current).toEqual(false)
+    store.updateState({
+      loading: true
+    })
+    render.rerender()
+    expect(render.result.current).toEqual(true)
+  })
+
+  it("registers onChange on mount", () => {
+    store.onChange = vi.fn()
+    store.clearOnChange = vi.fn()
+
+    renderHookWithProviders(() => useNostoState(state => state.loading), { store })
+
+    expect(store.onChange).toHaveBeenCalled()
+    expect(store.clearOnChange).not.toHaveBeenCalled()
+  })
+
+  it("clears out the store registration on unmount", () => {
+    const render = renderHookWithProviders(() => useNostoState(state => state.loading), { store })
+
+    store.clearOnChange = vi.fn()
+    render.unmount()
+
+    expect(store.clearOnChange).toHaveBeenCalled()
+  })
+})

--- a/packages/preact/test/mocks/mocks.ts
+++ b/packages/preact/test/mocks/mocks.ts
@@ -1,0 +1,5 @@
+import { createStore, State } from "@preact/store"
+
+export function mockStore(state: Partial<State>) {
+  return createStore(state)
+}

--- a/packages/preact/test/mocks/renderHookWithProviders.tsx
+++ b/packages/preact/test/mocks/renderHookWithProviders.tsx
@@ -1,0 +1,31 @@
+import { createStore, Store } from "@preact/store"
+import { StoreProvider } from "@preact/storeContext"
+import { renderHook, RenderHookOptions, RenderHookResult } from "@testing-library/preact"
+
+type ExtendedOptions<Props> = RenderHookOptions<Props> & { store?: Store }
+
+export function renderHookWithProviders<Result, Props>(
+  render: (initialProps: Props) => Result,
+  options?: ExtendedOptions<Props>
+): RenderHookResult<Result, Props> {
+  return renderHook(render, { ...options, wrapper: makeWrapper(options) })
+}
+
+function makeWrapper<Props>(options: ExtendedOptions<Props> = {}) {
+  const store = options.store ?? createStore({})
+  const UserWrapper = options.wrapper
+
+  if (!UserWrapper) {
+    return function Wrapper({ children }: { children: Element }) {
+      return <StoreProvider store={store}>{children}</StoreProvider>
+    }
+  }
+
+  return function Wrapper({ children }: { children: Element }) {
+    return (
+      <StoreProvider store={store}>
+        <UserWrapper>{children}</UserWrapper>
+      </StoreProvider>
+    )
+  }
+}

--- a/packages/utils/src/deepFreeze.ts
+++ b/packages/utils/src/deepFreeze.ts
@@ -1,0 +1,22 @@
+import { isPlainObject } from "./isPlainObject"
+import { Equals, Expect } from "./types"
+
+export const deepFreeze = <T extends object>(obj: T): Readonly<Freeze<T>> => {
+  const frozenObj = Object.entries(obj).reduce((acc, [key, value]) => {
+    const frozenValue = isPlainObject(value) ? deepFreeze(value) : Object.freeze(value)
+    return {
+      ...acc,
+      [key]: frozenValue
+    }
+  }, {} as Freeze<T>)
+
+  return Object.freeze(frozenObj)
+}
+
+type Freeze<T> = T extends object ? Readonly<{ [K in keyof T]: Freeze<T[K]> }> : T
+
+export type DeepFreezeTests = [
+  Expect<Equals<Freeze<{ a: string }>, { readonly a: string }>>,
+  Expect<Equals<Freeze<{ a: { b: number } }>, { readonly a: { readonly b: number } }>>,
+  Expect<Equals<Freeze<{ a: string[] }>, { readonly a: readonly string[] }>>
+]

--- a/packages/utils/src/deepMerge.ts
+++ b/packages/utils/src/deepMerge.ts
@@ -1,0 +1,34 @@
+import { isPlainObject } from "./isPlainObject"
+import type { Simplify } from "./simplify"
+import type { Equals, Expect } from "./types"
+
+export function deepMerge<T extends unknown[]>(...objects: T): Merge<T> {
+  return objects.reduce((prev, current) => mergeRecursive(prev, current)) as unknown as Merge<T>
+}
+
+function mergeRecursive(target: unknown, overrides: unknown): unknown {
+  if (isPlainObject(target) && isPlainObject(overrides)) {
+    return Object.entries(overrides).reduce(
+      (prev, [key, value]) => {
+        prev[key] = mergeRecursive(prev[key], value)
+        return prev
+      },
+      { ...target }
+    )
+  }
+
+  return overrides
+}
+
+type Merge<T, U = unknown> = T extends [infer First, ...infer Rest] ? Merge<Rest, U & First> : Simplify<U>
+
+export type MergeTests = [
+  // simple object merging
+  Expect<Equals<Merge<[{ a: string }, { b: number }]>, { a: string; b: number }>>,
+  // merge incompatible field types
+  Expect<Equals<Merge<[{ a: string }, { a: number }]>, { a: string & number }>>,
+  // merge compatible field types
+  Expect<Equals<Merge<[{ a: string | undefined }, { a: string }]>, { a: string }>>,
+  // merge multiple types
+  Expect<Equals<Merge<[{ a: string }, { b: number }, { c: boolean }]>, { a: string; b: number; c: boolean }>>
+]

--- a/packages/utils/src/isEqual.ts
+++ b/packages/utils/src/isEqual.ts
@@ -1,0 +1,25 @@
+import { isPlainObject } from "./isPlainObject"
+
+export function isEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true
+  }
+  if (a instanceof Date && b instanceof Date) {
+    return a.getTime() === b.getTime()
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false
+    }
+    return a.every((v, i) => isEqual(v, b[i]))
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const entriesA = Object.entries(a)
+
+    if (entriesA.length !== Object.keys(b).length) {
+      return false
+    }
+    return entriesA.every(([k, v]) => isEqual(v, b[k]))
+  }
+  return false
+}

--- a/packages/utils/src/isPlainObject.ts
+++ b/packages/utils/src/isPlainObject.ts
@@ -1,0 +1,20 @@
+const isObject = (v: unknown): v is object => String(v) === "[object Object]"
+
+export function isPlainObject<T = Record<string, unknown>>(value: unknown): value is T {
+  if (!isObject(value)) {
+    return false
+  }
+  const constructor = value.constructor
+  if (constructor === undefined) {
+    return true
+  }
+  const prototype = constructor.prototype
+  if (!isObject(prototype)) {
+    return false
+  }
+  // eslint-ignore-next-line no-prototype-builtins
+  if (!prototype.hasOwnProperty("isPrototypeOf")) {
+    return false
+  }
+  return true
+}

--- a/packages/utils/src/mergeArrays.ts
+++ b/packages/utils/src/mergeArrays.ts
@@ -1,0 +1,10 @@
+export function mergeArrays<T extends (unknown[] | undefined | null)[]>(...objects: T): T[number] {
+  if (objects.every(object => object === undefined || object === null)) {
+    return undefined
+  }
+  return objects
+    .filter(object => Array.isArray(object))
+    .reduce((prev, current) => {
+      return prev!.concat(current)
+    }, [])
+}

--- a/packages/utils/src/simplify.ts
+++ b/packages/utils/src/simplify.ts
@@ -1,0 +1,7 @@
+import { Equals, Expect } from "./types"
+
+export type Simplify<T> = T extends infer O ? { [K in keyof O]: O[K] } : never
+
+export type simplifyTests = [
+  Expect<Equals<Simplify<{ firstName: string } & { lastName: string }>, { firstName: string; lastName: string }>>
+]

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,0 +1,6 @@
+// type tests
+export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
+
+export type Expect<T extends true> = T
+
+export type MaybeArray<T> = T | T[]

--- a/packages/utils/test/deepFreeze.spec.ts
+++ b/packages/utils/test/deepFreeze.spec.ts
@@ -1,0 +1,13 @@
+import { deepFreeze } from "@utils/deepFreeze"
+import { describe, expect, it } from "vitest"
+
+describe("deepFreeze", () => {
+  it("should freeze the object", () => {
+    const testObject = { a: 1, b: { c: "string" } }
+    const result = deepFreeze(testObject)
+    expect(result).toEqual(testObject)
+    expect(result).not.toBe(testObject)
+    expect(() => Object.assign(result, { a: 2 })).toThrow()
+    expect(() => Object.assign(result.b, { c: "str" })).toThrow()
+  })
+})

--- a/packages/utils/test/deepMerge.spec.ts
+++ b/packages/utils/test/deepMerge.spec.ts
@@ -1,0 +1,38 @@
+import { deepMerge } from "@utils/deepMerge"
+import { describe, expect, it } from "vitest"
+
+describe("merge", () => {
+  it("merges plain objects correctly", () => {
+    expect(deepMerge({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 })
+  })
+
+  it("merges deep objects correctly", () => {
+    expect(
+      deepMerge(
+        {
+          deep: {
+            foo: 12
+          }
+        },
+        {
+          deep: {
+            bar: 2
+          },
+          shallow: 100
+        }
+      )
+    ).toEqual({
+      deep: {
+        foo: 12,
+        bar: 2
+      },
+      shallow: 100
+    })
+  })
+
+  it("overrides deep arrays", () => {
+    expect(deepMerge({ deep: ["foo"] }, { deep: ["bar"] })).toEqual({
+      deep: ["bar"]
+    })
+  })
+})

--- a/packages/utils/test/mergeArrays.spec.tsx
+++ b/packages/utils/test/mergeArrays.spec.tsx
@@ -1,0 +1,20 @@
+import { mergeArrays } from "@utils/mergeArrays"
+import { describe, expect, it } from "vitest"
+
+describe("mergeArrays", () => {
+  it("merges arrays correctly", () => {
+    expect(mergeArrays(["foo"], ["bar"], ["qip"])).toEqual(["foo", "bar", "qip"])
+  })
+
+  it("ignores undefined values", () => {
+    expect(mergeArrays(["foo"], undefined, ["qip"])).toEqual(["foo", "qip"])
+  })
+
+  it("ignores null values", () => {
+    expect(mergeArrays(["foo"], null, ["qip"])).toEqual(["foo", "qip"])
+  })
+
+  it("returns undefined if all are undefined or null", () => {
+    expect(mergeArrays(undefined, null)).toEqual(undefined)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,8 @@
     "noFallthroughCasesInSwitch": true,
 
     /* JSX */
-    "jsx": "react",
-    "jsxFactory": "h",
-    "jsxFragmentFactory": "Fragment",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
 
     /* Alias */
     "baseUrl": ".",
@@ -31,7 +30,8 @@
       "@core/*": ["packages/core/src/*"],
       "@currencies/*": ["packages/currencies/src/*"],
       "@preact/*": ["packages/preact/src/*"],
-      "@thumbnails/*": ["packages/thumbnails/src/*"]
+      "@thumbnails/*": ["packages/thumbnails/src/*"],
+      "@utils/*": ["packages/utils/src/*"],
     }
-  }  
+  },
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,8 @@ export const baseConfig = {
       "@core": resolve(import.meta.dirname, "packages/core/src"),
       "@currencies": resolve(import.meta.dirname, "packages/currencies/src"),
       "@preact": resolve(import.meta.dirname, "packages/preact/src"),
-      "@thumbnails": resolve(import.meta.dirname, "packages/thumbnails/src")
+      "@thumbnails": resolve(import.meta.dirname, "packages/thumbnails/src"),
+      "@utils": resolve(import.meta.dirname, "packages/utils/src")
     }
   },
   test: {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Moves the state management from the library into search-js preact package.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-797
