### PR TITLE
fix: useNostoAppState types

### DIFF
--- a/packages/preact/src/hooks/useNostoAppState.ts
+++ b/packages/preact/src/hooks/useNostoAppState.ts
@@ -40,6 +40,8 @@ import { useContext, useEffect, useState } from "preact/hooks"
  *
  * @group Hooks
  */
+export function useNostoAppState(): State
+export function useNostoAppState<Selected>(selector: (state: State) => Selected): Selected
 export function useNostoAppState<Selected>(selector: (state: State) => Selected = fullStateSelector<Selected>) {
   const store = useContext(StoreContext)
   const [slice, setSlice] = useState(selector(store.getState()))

--- a/packages/preact/test/hooks/useNostoAppState.spec.tsx
+++ b/packages/preact/test/hooks/useNostoAppState.spec.tsx
@@ -1,4 +1,5 @@
 import { useNostoAppState } from "@preact/hooks/useNostoAppState"
+import { State } from "@preact/store"
 import { describe, expect, it, vi } from "vitest"
 
 import { mockStore } from "../mocks/mocks"
@@ -18,9 +19,17 @@ describe("useNostoAppState", () => {
     }
   })
 
+  it("returns the entire state without selector", () => {
+    const render = renderHookWithProviders(() => useNostoAppState(), { store })
+
+    expect<State>(render.result.current)
+    expect(render.result.current).toEqual(store.getInitialState())
+  })
+
   it("returns the entire state when selected", () => {
     const render = renderHookWithProviders(() => useNostoAppState(state => state), { store })
 
+    expect<State>(render.result.current)
     expect(render.result.current).toEqual(store.getInitialState())
   })
 


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
useNostoAppState was returning `unknown` if the selector is not provided. I thought I tested it, but I guess I missed the case. Now tests have a type assertion as well.
