### PR TITLE
chore: move useFacet and useSort

### DIFF
--- a/packages/preact/src/hooks/useFacet.ts
+++ b/packages/preact/src/hooks/useFacet.ts
@@ -1,0 +1,74 @@
+import type { SearchTermsFacet } from "@nosto/nosto-js/client"
+import { useState } from "preact/hooks"
+
+import { useActions } from "./useActions"
+
+/**
+ * Preact hook that import facet state to the component.
+ * @param facet
+ * @example
+ * ```jsx
+ * import { useFacet } from '@nosto/search-js/preact'
+ *
+ * export default () => {
+ *     const { active, selectedFiltersCount, toggleActive, toggleProductFilter } = useFacet(facet)
+ *     return (
+ *         <li class={`ns-sidebar-dropdown ${active ? "ns-active" : ""}`}>
+ *             <span
+ *                 onClick={toggleActive}
+ *             >
+ *                 <span>{facet.name}</span>
+ *                 {selectedFiltersCount > 0 && (
+ *                     <span>{selectedFiltersCount}</span>
+ *                 )}
+ *             </span>
+ *             <div>
+ *                 <ul>
+ *                     {facet.data?.map(value => (
+ *                         <li key={value.value}>
+ *                             <label>
+ *                                 {value.value}
+ *                                 <input
+ *                                     type="checkbox"
+ *                                     checked={value.selected}
+ *                                     onChange={e => {
+ *                                         e.preventDefault()
+ *                                         toggleProductFilter(
+ *                                             facet.field,
+ *                                             value.value,
+ *                                             !value.selected
+ *                                         )
+ *                                     }}
+ *                                 />
+ *                             </label>
+ *                             <span>{value.count}</span>
+ *                         </li>
+ *                     ))}
+ *                 </ul>
+ *             </div>
+ *         </li>
+ *     );
+ * }
+ * ```
+ * @group Hooks
+ */
+export function useFacet(facet: SearchTermsFacet) {
+  const selectedFiltersCount = facet.data?.filter(v => v.selected).length ?? 0
+  const [active, setActive] = useState(selectedFiltersCount > 0)
+  const { toggleProductFilter } = useActions()
+
+  const toggleActive = () => {
+    setActive(!active)
+  }
+
+  return {
+    /** Active value */
+    active,
+    /** Selected filters count */
+    selectedFiltersCount,
+    /** Toggle active function */
+    toggleActive,
+    /** Toggle product filter function */
+    toggleProductFilter
+  }
+}

--- a/packages/preact/src/hooks/useSort/useSort.ts
+++ b/packages/preact/src/hooks/useSort/useSort.ts
@@ -1,0 +1,72 @@
+import { InputSearchSort } from "@nosto/nosto-js/client"
+
+import { useActions } from "../useActions"
+import { useNostoAppState } from "../useNostoAppState"
+import { isMatchingSort } from "./utils"
+
+export interface SortOption {
+  id: string
+  value: {
+    name: string
+    sort: InputSearchSort[]
+  }
+}
+
+/**
+ * Preact hook that import sort state to the component.
+ * @param sortOptions
+ * @example
+ * ```jsx
+ * import { useSort } from '@nosto/search-js/preact'
+ * import { sortOptions } from '../config'
+ *
+ * export default () => {
+ *    const { activeSort, setSort } = useSort(sortOptions)
+ *
+ *    const handleSortChange = (event) => {
+ *        setSort(event.target.value)
+ *    }
+ *
+ *    return (
+ *        <div>
+ *            <select
+ *                value={activeSort}
+ *                onChange={e => setSort(e.target.value)}
+ *            >
+ *                {sortOptions.map(option => (
+ *                    <option key={option.id} value={option.id}>
+ *                        {option.value.name}
+ *                    </option>
+ *                ))}
+ *            </select>
+ *        </div>
+ *    )
+ * }
+ * ```
+ * @group Hooks
+ */
+export function useSort(sortOptions: SortOption[]) {
+  const query = useNostoAppState(state => state.query)
+  const { updateSearch } = useActions()
+
+  const activeSort =
+    sortOptions.find(option => isMatchingSort(option.value.sort, query.products?.sort || []))?.id ?? sortOptions[0]?.id
+
+  const setSort = (sortId: string) => {
+    const selectedSort = sortOptions.find(option => option.id === sortId)
+    if (selectedSort) {
+      updateSearch({
+        products: {
+          sort: selectedSort.value.sort
+        }
+      })
+    }
+  }
+
+  return {
+    /** Active sort */
+    activeSort,
+    /** Set sort function */
+    setSort
+  }
+}

--- a/packages/preact/src/hooks/useSort/utils.ts
+++ b/packages/preact/src/hooks/useSort/utils.ts
@@ -1,0 +1,12 @@
+import type { InputSearchSort } from "@nosto/nosto-js/client"
+
+export function createSortOption(id: string, name: string, ...sort: InputSearchSort[]) {
+  return { id, value: { name, sort } }
+}
+
+export function isMatchingSort(optionSort: InputSearchSort[], querySort: InputSearchSort[]) {
+  if (optionSort.length !== querySort.length) {
+    return false
+  }
+  return optionSort.every(v1 => querySort.find(v2 => v1.field === v2.field && v1.order === v2.order))
+}

--- a/packages/preact/test/hooks/useSort.spec.ts
+++ b/packages/preact/test/hooks/useSort.spec.ts
@@ -1,0 +1,81 @@
+import { useSort } from "@preact/hooks/useSort/useSort"
+import { createSortOption, isMatchingSort } from "@preact/hooks/useSort/utils"
+import { describe, expect, it } from "vitest"
+
+import { mockActions, mockStore } from "../mocks/mocks"
+import { renderHookWithProviders } from "../mocks/renderHookWithProviders"
+
+const sortOptions = [
+  createSortOption("default", "Sort by"),
+  createSortOption("score", "Most relevant", { field: "score", order: "desc" })
+]
+
+describe("useSort", () => {
+  const store = mockStore({
+    loading: false,
+    initialized: true,
+    query: {
+      products: {
+        sort: []
+      }
+    },
+    response: {
+      products: {
+        size: 10,
+        total: 100,
+        hits: []
+      }
+    }
+  })
+
+  const actions = mockActions()
+
+  it("returns correct sort options creations", () => {
+    const sortOption = createSortOption("default", "Sort by")
+    expect(sortOption).toEqual({ id: "default", value: { name: "Sort by", sort: [] } })
+    const sortOptionScore = createSortOption("score", "Most relevant", { field: "score", order: "desc" })
+    expect(sortOptionScore).toEqual({
+      id: "score",
+      value: {
+        name: "Most relevant",
+        sort: [
+          {
+            field: "score",
+            order: "desc"
+          }
+        ]
+      }
+    })
+  })
+  it("returns correct initial values", () => {
+    const { activeSort } = renderHookWithProviders(() => useSort(sortOptions), { store }).result.current
+    expect(activeSort).toBe("default")
+  })
+
+  it("handles sort change correctly", () => {
+    const { setSort } = renderHookWithProviders(() => useSort(sortOptions), { store }).result.current
+
+    setSort("score")
+    expect(actions.updateSearch).toHaveBeenCalledWith({
+      products: {
+        sort: [{ field: "score", order: "desc" }]
+      }
+    })
+    setSort("default")
+    expect(actions.updateSearch).toHaveBeenCalledWith({
+      products: {
+        sort: []
+      }
+    })
+  })
+
+  it("returns correct matching sort", () => {
+    const scoreSortOpt = createSortOption("score", "Most relevant", { field: "score", order: "asc" })
+    const scoreSortQry = createSortOption("score", "Most relevant", { field: "score", order: "asc" })
+    const scoreSortDesc = createSortOption("score", "Most relevant", { field: "score", order: "desc" })
+    expect(isMatchingSort(scoreSortOpt.value.sort, scoreSortQry.value.sort)).toBe(true)
+    expect(isMatchingSort(scoreSortOpt.value.sort, scoreSortDesc.value.sort)).toBe(false)
+    expect(isMatchingSort(scoreSortOpt.value.sort, [])).toBe(false)
+    expect(isMatchingSort([], [])).toBe(true)
+  })
+})

--- a/packages/preact/test/mocks/mocks.ts
+++ b/packages/preact/test/mocks/mocks.ts
@@ -1,5 +1,18 @@
+import * as useActions from "@preact/hooks/useActions"
 import { createStore, State } from "@preact/store"
+import { vi } from "vitest"
 
 export function mockStore(state: Partial<State>) {
   return createStore(state)
+}
+
+export function mockActions() {
+  const actions = {
+    newSearch: vi.fn(),
+    updateSearch: vi.fn(),
+    toggleProductFilter: vi.fn(),
+    replaceFilter: vi.fn()
+  }
+  vi.spyOn(useActions, "useActions").mockImplementation(() => actions)
+  return actions
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Moves useFacet and useSort. The tests are also moved, but only useSort had any tests in the library.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
Same old
