### PR TITLE
fix: remove postinstall script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+      
+      - name: Install dev app dependencies
+        working-directory: ./dev/preact
+        run: npm ci
 
       - name: Run build
         run: npm run build

--- a/dev/preact/package-lock.json
+++ b/dev/preact/package-lock.json
@@ -28,7 +28,6 @@
 			"name": "@nosto/search-js",
 			"version": "0.1.0",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "ISC",
 			"workspaces": [
 				"packages/*"
@@ -51,7 +50,7 @@
 				"jsdom": "^26.0.0",
 				"prettier": "^3.5.3",
 				"typedoc": "^0.27.9",
-				"typescript": "^5.7.3",
+				"typescript": "^5.8.2",
 				"typescript-eslint": "^8.26.0",
 				"vite": "^6.2.1",
 				"vite-plugin-dts": "^4.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@nosto/search-js",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:watch": "vitest",
     "lint": "eslint",
     "lint-fix": "eslint --fix",
-    "postinstall": "(cd dev/preact && npm i --ignore-scripts)"
+    "install:dev": "(cd dev/preact && npm i --ignore-scripts)"
   },
   "devDependencies": {
     "@nosto/nosto-js": "^1.5.0",


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Apparently yarn attempts to run lifecycle scripts even for dependencies, so this line breaks the build 🤦‍♀️.

TS bump unrelated, but happened automatically