### PR TITLE
chore: pin semantic release action sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm test
 
       - name: Publish project
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@0a51e81a6baff2acad3ee88f4121c589c73d0f0e # v4.2.0
         id: semantic
         with:
           extra_plugins: |


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Pins the SHA of the semantic releases github actions for improved security.

The SHA used is the [commit ID](https://github.com/cycjimmy/semantic-release-action/commit/0a51e81a6baff2acad3ee88f4121c589c73d0f0e) corresponding to the latest tag.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/HEALTH-1164

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
