### PR TITLE
feat: Move input binding logic to reusable bindElementListeners

### DIFF
--- a/packages/utils/src/bindElementListeners.ts
+++ b/packages/utils/src/bindElementListeners.ts
@@ -1,0 +1,96 @@
+export type InputBindingCallbacks = {
+  onSubmit?: (value: string) => void
+  onInput?: (value: string) => void
+  onFocus?: (value: string) => void
+  onBlur?: (value: string) => void
+  onKeyDown?: (value: string, key: string) => void
+  onClick?: (value: string) => void
+}
+
+export interface BindElementOptions {
+  form?: HTMLFormElement
+  allowNativeSubmit?: boolean
+}
+
+export function bindElementListeners(
+  target: HTMLInputElement,
+  callbacks: InputBindingCallbacks,
+  options: BindElementOptions = {}
+): {
+  destroy: () => void
+} {
+  const unbindCallbacks = [target].flatMap(el => {
+    const cbs: Array<() => void> = []
+    const form = options.form !== undefined ? options.form : el.form
+
+    if (callbacks.onSubmit) {
+      const onKeyDown = (event: KeyboardEvent) => {
+        callbacks.onKeyDown?.(el.value, event.key)
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          event.preventDefault()
+        }
+
+        if (event.key === "Enter") {
+          if (el.value !== "" && !event.repeat) {
+            callbacks.onSubmit?.(el.value)
+          }
+          event.preventDefault()
+        }
+      }
+      el.addEventListener("keydown", onKeyDown)
+      cbs.push(() => {
+        el.removeEventListener("keydown", onKeyDown)
+      })
+
+      // TODO: Add allowNativeSubmit option
+      if (form) {
+        const onSubmit = (event: SubmitEvent) => {
+          event.preventDefault()
+          callbacks.onSubmit?.(el.value)
+        }
+
+        form.addEventListener("submit", onSubmit)
+        cbs.push(() => form.removeEventListener("submit", onSubmit))
+
+        const buttons = Array.from(form.querySelectorAll("[type=submit]"))
+        buttons.forEach(button => {
+          const onClick = (event: Event) => {
+            event.preventDefault()
+            callbacks.onSubmit?.(el.value)
+          }
+
+          button.addEventListener("click", onClick)
+          cbs.push(() => {
+            button.removeEventListener("click", onClick)
+          })
+        })
+      }
+    }
+
+    if (callbacks.onClick) {
+      const onClick = () => callbacks.onClick?.(el.value)
+      el.addEventListener("click", onClick)
+      cbs.push(() => el.removeEventListener("click", onClick))
+    }
+
+    if (callbacks.onFocus) {
+      const onFocus = () => callbacks.onFocus?.(el.value)
+      el.addEventListener("focus", onFocus)
+      cbs.push(() => el.removeEventListener("focus", onFocus))
+    }
+
+    if (callbacks.onInput) {
+      const onInput = () => callbacks.onInput?.(el.value)
+      el.addEventListener("input", onInput)
+      cbs.push(() => el.removeEventListener("input", onInput))
+    }
+
+    return cbs
+  })
+
+  return {
+    destroy() {
+      unbindCallbacks.forEach(v => v())
+    }
+  }
+}

--- a/packages/utils/src/bindElementListeners.ts
+++ b/packages/utils/src/bindElementListeners.ts
@@ -2,7 +2,6 @@ export type InputBindingCallbacks = {
   onSubmit?: (value: string) => void
   onInput?: (value: string) => void
   onFocus?: (value: string) => void
-  onBlur?: (value: string) => void
   onKeyDown?: (value: string, key: string) => void
   onClick?: (value: string) => void
 }
@@ -21,7 +20,7 @@ export function bindElementListeners(
 } {
   const unbindCallbacks = [target].flatMap(el => {
     const cbs: Array<() => void> = []
-    const form = options.form !== undefined ? options.form : el.form
+    const form = options?.form !== undefined ? options.form : el.form
 
     if (callbacks.onSubmit) {
       const onKeyDown = (event: KeyboardEvent) => {
@@ -42,13 +41,11 @@ export function bindElementListeners(
         el.removeEventListener("keydown", onKeyDown)
       })
 
-      // TODO: Add allowNativeSubmit option
-      if (form) {
+      if (form && !options.allowNativeSubmit) {
         const onSubmit = (event: SubmitEvent) => {
           event.preventDefault()
           callbacks.onSubmit?.(el.value)
         }
-
         form.addEventListener("submit", onSubmit)
         cbs.push(() => form.removeEventListener("submit", onSubmit))
 

--- a/packages/utils/test/bindElementListeners.spec.ts
+++ b/packages/utils/test/bindElementListeners.spec.ts
@@ -1,0 +1,143 @@
+import { bindElementListeners, InputBindingCallbacks } from "../src/bindElementListeners"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+describe("bindElementListeners", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+  it("should bind and unbind keydown listener when onSubmit is provided", () => {
+    const el = document.createElement("input")
+    const callbacks: InputBindingCallbacks = {
+      onSubmit: vi.fn(),
+      onKeyDown: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks)
+
+    const event = new KeyboardEvent("keydown", { key: "Enter" })
+    el.value = "test"
+    el.dispatchEvent(event)
+
+    expect(callbacks.onSubmit).toHaveBeenCalledWith("test")
+    expect(callbacks.onKeyDown).toHaveBeenCalledWith("test", "Enter")
+
+    destroy()
+
+    el.dispatchEvent(event)
+    expect(callbacks.onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("should prevent default on ArrowDown and ArrowUp keydown events", () => {
+    const el = document.createElement("input")
+    document.body.appendChild(el)
+
+    const callbacks: InputBindingCallbacks = {
+      onSubmit: vi.fn()
+    }
+    const { destroy } = bindElementListeners(el, callbacks)
+
+    const keyDownEventOptions = {
+      bubbles: true,
+      cancelable: true
+    }
+
+    const arrowDownEvent = new KeyboardEvent("keydown", { ...keyDownEventOptions, key: "ArrowDown" })
+    const arrowUpEvent = new KeyboardEvent("keydown", { ...keyDownEventOptions, key: "ArrowUp" })
+    el.dispatchEvent(arrowDownEvent)
+    el.dispatchEvent(arrowUpEvent)
+    expect(arrowDownEvent.defaultPrevented).toBe(true)
+    expect(arrowUpEvent.defaultPrevented).toBe(true)
+
+    destroy()
+  })
+
+  it("should bind and unbind submit listener to the form", () => {
+    const el = document.createElement("input")
+    const form = document.createElement("form")
+    form.appendChild(el)
+    document.body.appendChild(form)
+
+    const callbacks: InputBindingCallbacks = {
+      onSubmit: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks, { form })
+
+    const event = new SubmitEvent("submit", { bubbles: true, cancelable: true })
+    form.dispatchEvent(event)
+
+    expect(callbacks.onSubmit).toHaveBeenCalledWith(el.value)
+    expect(event.defaultPrevented).toBe(true)
+
+    destroy()
+  })
+
+  it("should bind and unbind click listener to submit buttons in the form", () => {
+    const el = document.createElement("input")
+    const form = document.createElement("form")
+    const button = document.createElement("button")
+    button.type = "submit"
+    form.appendChild(el)
+    form.appendChild(button)
+    document.body.appendChild(form)
+
+    const callbacks: InputBindingCallbacks = {
+      onSubmit: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks, { form })
+
+    const event = new Event("click", { bubbles: true, cancelable: true })
+    button.dispatchEvent(event)
+
+    expect(callbacks.onSubmit).toHaveBeenCalledWith(el.value)
+    expect(event.defaultPrevented).toBe(true)
+
+    destroy()
+  })
+
+  it("should bind and unbind click listener when onClick is provided", () => {
+    const el = document.createElement("input")
+    const callbacks: InputBindingCallbacks = {
+      onClick: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks)
+
+    el.dispatchEvent(new Event("click"))
+
+    expect(callbacks.onClick).toHaveBeenCalledWith(el.value)
+
+    destroy()
+  })
+
+  it("should bind and unbind focus listener when onFocus is provided", () => {
+    const el = document.createElement("input")
+    const callbacks: InputBindingCallbacks = {
+      onFocus: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks)
+
+    el.dispatchEvent(new Event("focus"))
+
+    expect(callbacks.onFocus).toHaveBeenCalledWith(el.value)
+
+    destroy()
+  })
+
+  it("should bind and unbind input listener when onInput is provided", () => {
+    const el = document.createElement("input")
+    const callbacks: InputBindingCallbacks = {
+      onInput: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks)
+
+    el.dispatchEvent(new Event("input"))
+
+    expect(callbacks.onInput).toHaveBeenCalledWith(el.value)
+
+    destroy()
+  })
+})

--- a/packages/utils/test/bindElementListeners.spec.ts
+++ b/packages/utils/test/bindElementListeners.spec.ts
@@ -1,5 +1,6 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
 import { bindElementListeners, InputBindingCallbacks } from "../src/bindElementListeners"
-import { describe, expect, it, vi, beforeEach } from "vitest"
 
 describe("bindElementListeners", () => {
   beforeEach(() => {
@@ -137,6 +138,28 @@ describe("bindElementListeners", () => {
     el.dispatchEvent(new Event("input"))
 
     expect(callbacks.onInput).toHaveBeenCalledWith(el.value)
+
+    destroy()
+  })
+
+  it("should allow native submit when allowNativeSubmit is true", () => {
+    const el = document.createElement("input")
+    el.value = "test"
+    const form = document.createElement("form")
+    form.appendChild(el)
+    document.body.appendChild(form)
+
+    const callbacks: InputBindingCallbacks = {
+      onSubmit: vi.fn()
+    }
+
+    const { destroy } = bindElementListeners(el, callbacks, { form, allowNativeSubmit: true })
+
+    const event = new SubmitEvent("submit", { bubbles: true, cancelable: true })
+    form.dispatchEvent(event)
+
+    expect(callbacks.onSubmit).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
 
     destroy()
   })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

Extracted input binding logic used in search-templates and nosto-autocomplete to core bindElementListeners util.

New feature:
* `allowNativeSubmit` will allow developers to opt-in for form native submit behavior 

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

https://nostosolutions.atlassian.net/browse/CFE-1007 (related to allowNativeSubmit)
https://nostosolutions.atlassian.net/browse/CFE-1009

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
