### PR TITLE
fix: remove onSubmit triggering in onKeyDown

### DIFF
--- a/packages/utils/src/bindInput.ts
+++ b/packages/utils/src/bindInput.ts
@@ -31,7 +31,9 @@ export function bindInput(
   if (onKeyDown || onSubmit) {
     addEventListener(target, "keydown", (event: KeyboardEvent) => {
       onKeyDown?.(target.value, event.key)
-      if (event.key === "ArrowDown" || event.key === "ArrowUp" || (onSubmit && event.key === "Enter")) {
+      if (onKeyDown && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+        event.preventDefault()
+      } else if (onSubmit && event.key === "Enter") {
         event.preventDefault()
       }
     })

--- a/packages/utils/src/bindInput.ts
+++ b/packages/utils/src/bindInput.ts
@@ -31,12 +31,7 @@ export function bindInput(
   if (onKeyDown || onSubmit) {
     addEventListener(target, "keydown", (event: KeyboardEvent) => {
       onKeyDown?.(target.value, event.key)
-      if (onKeyDown && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
-        event.preventDefault()
-      } else if (onSubmit && event.key === "Enter") {
-        if (target.value !== "" && !event.repeat) {
-          onSubmit(target.value)
-        }
+      if (event.key === "ArrowDown" || event.key === "ArrowUp" || (onSubmit && event.key === "Enter")) {
         event.preventDefault()
       }
     })

--- a/packages/utils/test/bindInput.spec.ts
+++ b/packages/utils/test/bindInput.spec.ts
@@ -2,6 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { bindInput } from "../src/bindInput"
 
+const eventOptions = {
+  bubbles: true,
+  cancelable: true
+}
+
 describe("bindInput", () => {
   beforeEach(() => {
     document.body.innerHTML = ""
@@ -30,17 +35,23 @@ describe("bindInput", () => {
     }
     bindInput(el, callbacks)
 
-    const keyDownEventOptions = {
-      bubbles: true,
-      cancelable: true
-    }
-
-    const arrowDownEvent = new KeyboardEvent("keydown", { ...keyDownEventOptions, key: "ArrowDown" })
-    const arrowUpEvent = new KeyboardEvent("keydown", { ...keyDownEventOptions, key: "ArrowUp" })
+    const arrowDownEvent = new KeyboardEvent("keydown", { ...eventOptions, key: "ArrowDown" })
+    const arrowUpEvent = new KeyboardEvent("keydown", { ...eventOptions, key: "ArrowUp" })
     el.dispatchEvent(arrowDownEvent)
     el.dispatchEvent(arrowUpEvent)
     expect(arrowDownEvent.defaultPrevented).toBe(true)
     expect(arrowUpEvent.defaultPrevented).toBe(true)
+  })
+
+  it("should prevent default on Enter keydown event when onSubmit is provided", () => {
+    const el = document.createElement("input")
+    const callbacks = {
+      onSubmit: vi.fn()
+    }
+    bindInput(el, callbacks)
+    const event = new KeyboardEvent("keydown", { ...eventOptions, key: "Enter" })
+    el.dispatchEvent(event)
+    expect(event.defaultPrevented).toBe(true)
   })
 
   it("should bind and unbind submit listener to the form", () => {
@@ -55,7 +66,7 @@ describe("bindInput", () => {
 
     bindInput(el, callbacks, { form })
 
-    const event = new SubmitEvent("submit", { bubbles: true, cancelable: true })
+    const event = new SubmitEvent("submit", eventOptions)
     form.dispatchEvent(event)
 
     expect(callbacks.onSubmit).toHaveBeenCalledWith(el.value)
@@ -77,7 +88,7 @@ describe("bindInput", () => {
 
     bindInput(el, callbacks, { form })
 
-    const event = new Event("click", { bubbles: true, cancelable: true })
+    const event = new Event("click", eventOptions)
     button.dispatchEvent(event)
 
     expect(callbacks.onSubmit).toHaveBeenCalledWith(el.value)

--- a/packages/utils/test/bindInput.spec.ts
+++ b/packages/utils/test/bindInput.spec.ts
@@ -6,26 +6,19 @@ describe("bindInput", () => {
   beforeEach(() => {
     document.body.innerHTML = ""
   })
-  it("should bind and unbind keydown listener when onSubmit is provided", () => {
+  it("should bind and unbind keydown listener", () => {
     const el = document.createElement("input")
     const callbacks = {
-      onSubmit: vi.fn(),
       onKeyDown: vi.fn()
     }
 
-    const { destroy } = bindInput(el, callbacks)
+    bindInput(el, callbacks)
 
     const event = new KeyboardEvent("keydown", { key: "Enter" })
     el.value = "test"
     el.dispatchEvent(event)
 
-    expect(callbacks.onSubmit).toHaveBeenCalledWith("test")
     expect(callbacks.onKeyDown).toHaveBeenCalledWith("test", "Enter")
-
-    destroy()
-
-    el.dispatchEvent(event)
-    expect(callbacks.onSubmit).toHaveBeenCalledTimes(1)
   })
 
   it("should prevent default on ArrowDown and ArrowUp keydown events", () => {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

Removes coupling of custom onSubmit fire on `KeyDown.Enter` event as the custom form submission will be handled in the submit event.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
