### PR TITLE
fix: add first and last page to pages array

### DIFF
--- a/packages/preact/src/hooks/usePagination.ts
+++ b/packages/preact/src/hooks/usePagination.ts
@@ -87,12 +87,20 @@ export function usePagination(options?: { width?: number }): {
 
     const prev = currentPage > 1 ? pageToPosition(currentPage - 1) : undefined
     const next = currentPage < totalPages ? pageToPosition(currentPage + 1) : undefined
-    const first = pagesToShow === Infinity || currentPage - pagesToShow - 1 > 1 ? pageToPosition(1) : undefined
-    const last =
-      pagesToShow === Infinity || currentPage + pagesToShow + 1 < totalPages ? pageToPosition(totalPages) : undefined
+    const first = currentPage - pagesToShow - 1 > 1 ? pageToPosition(1) : undefined
+    const last = currentPage + pagesToShow + 1 < totalPages ? pageToPosition(totalPages) : undefined
     const pages = range(1, totalPages + 1)
       .filter(showPage)
       .map(pageToPosition)
+
+    if (!first && pages[0]?.page === 2) {
+      // add first page to extended pages array
+      pages.unshift(pageToPosition(1))
+    }
+    if (!last && pages[pages.length - 1]?.page === totalPages - 1) {
+      // add last page to extended pages array
+      pages.push(pageToPosition(totalPages))
+    }
 
     return {
       totalPages,

--- a/packages/preact/test/hooks/usePagination.spec.ts
+++ b/packages/preact/test/hooks/usePagination.spec.ts
@@ -41,16 +41,18 @@ describe("usePagination", () => {
     return renderHookWithProviders(() => usePagination({ width }), { store }).result.current
   }
 
-  it("previous for first page is undefined", () => {
-    const { prev, next } = mockUsePagination(0, 100)
+  it("previous and first for first page is undefined", () => {
+    const { prev, first, next } = mockUsePagination(0, 100)
     expect(prev).toBeUndefined()
+    expect(first).toBeUndefined()
     expect(next).toEqual({ current: false, from: 10, page: 2 })
   })
 
-  it("next for last page is undefined", () => {
-    const { prev, next } = mockUsePagination(90, 100)
+  it("next and last for last page is undefined", () => {
+    const { prev, next, last } = mockUsePagination(90, 100)
     expect(prev).toEqual({ current: false, from: 80, page: 9 })
     expect(next).toBeUndefined()
+    expect(last).toBeUndefined()
   })
 
   it("pages content is valid", () => {
@@ -59,6 +61,42 @@ describe("usePagination", () => {
       { page: 1, from: 0, current: true },
       { page: 2, from: 10, current: false },
       { page: 3, from: 20, current: false }
+    ])
+  })
+
+  it("first is covered in pages array", () => {
+    const { first, pages, last } = mockUsePagination(50, 100, 10)
+    expect(first).toBeUndefined()
+    expect(last).toBeUndefined()
+    expect(pages).toEqual([
+      { page: 1, from: 0, current: false },
+      { page: 2, from: 10, current: false },
+      { page: 3, from: 20, current: false },
+      { page: 4, from: 30, current: false },
+      { page: 5, from: 40, current: false },
+      { page: 6, from: 50, current: true }, // current
+      { page: 7, from: 60, current: false },
+      { page: 8, from: 70, current: false },
+      { page: 9, from: 80, current: false },
+      { page: 10, from: 90, current: false }
+    ])
+  })
+
+  it("last is covered in pages array", () => {
+    const { first, pages, last } = mockUsePagination(40, 100, 10)
+    expect(first).toBeUndefined()
+    expect(last).toBeUndefined()
+    expect(pages).toEqual([
+      { page: 1, from: 0, current: false },
+      { page: 2, from: 10, current: false },
+      { page: 3, from: 20, current: false },
+      { page: 4, from: 30, current: false },
+      { page: 5, from: 40, current: true }, // current
+      { page: 6, from: 50, current: false },
+      { page: 7, from: 60, current: false },
+      { page: 8, from: 70, current: false },
+      { page: 9, from: 80, current: false },
+      { page: 10, from: 90, current: false }
     ])
   })
 })

--- a/packages/preact/test/hooks/usePagination.spec.ts
+++ b/packages/preact/test/hooks/usePagination.spec.ts
@@ -67,7 +67,6 @@ describe("usePagination", () => {
   it("first is covered in pages array", () => {
     const { first, pages, last } = mockUsePagination(50, 100, 10)
     expect(first).toBeUndefined()
-    expect(last).toBeUndefined()
     expect(pages).toEqual([
       { page: 1, from: 0, current: false },
       { page: 2, from: 10, current: false },
@@ -80,12 +79,28 @@ describe("usePagination", () => {
       { page: 9, from: 80, current: false },
       { page: 10, from: 90, current: false }
     ])
+    expect(last).toBeUndefined()
+  })
+
+  it("first is detached", () => {
+    const { first, pages, last } = mockUsePagination(60, 100, 10)
+    expect(first).toEqual({ current: false, from: 0, page: 1 })
+    expect(pages).toEqual([
+      { page: 3, from: 20, current: false },
+      { page: 4, from: 30, current: false },
+      { page: 5, from: 40, current: false },
+      { page: 6, from: 50, current: false },
+      { page: 7, from: 60, current: true }, // current
+      { page: 8, from: 70, current: false },
+      { page: 9, from: 80, current: false },
+      { page: 10, from: 90, current: false }
+    ])
+    expect(last).toBeUndefined()
   })
 
   it("last is covered in pages array", () => {
     const { first, pages, last } = mockUsePagination(40, 100, 10)
     expect(first).toBeUndefined()
-    expect(last).toBeUndefined()
     expect(pages).toEqual([
       { page: 1, from: 0, current: false },
       { page: 2, from: 10, current: false },
@@ -98,5 +113,22 @@ describe("usePagination", () => {
       { page: 9, from: 80, current: false },
       { page: 10, from: 90, current: false }
     ])
+    expect(last).toBeUndefined()
+  })
+
+  it("last is detached", () => {
+    const { first, pages, last } = mockUsePagination(30, 100, 10)
+    expect(first).toBeUndefined()
+    expect(pages).toEqual([
+      { page: 1, from: 0, current: false },
+      { page: 2, from: 10, current: false },
+      { page: 3, from: 20, current: false },
+      { page: 4, from: 30, current: true }, // current
+      { page: 5, from: 40, current: false },
+      { page: 6, from: 50, current: false },
+      { page: 7, from: 60, current: false },
+      { page: 8, from: 70, current: false }
+    ])
+    expect(last).toEqual({ current: false, from: 90, page: 10 })
   })
 })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Add first and last page to pages array in case the first and last field doesn't cover it

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
