### PR TITLE
Attempt: Improve typedoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "jsdom": "^26.1.0",
         "prettier": "^3.5.3",
         "typedoc": "^0.28.5",
+        "typedoc-plugin-missing-exports": "^4.0.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.1",
         "vite": "^6.3.5",
@@ -8797,6 +8798,16 @@
       },
       "peerDependencies": {
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-4.0.0.tgz",
+      "integrity": "sha512-Z4ei+853xppDEhcqzyeyRs4+R0kUuKQWnMK1EtSTEd5LFkgkdW5Bdn8vfo/rsCGbYVJxOWU99fxgM1mROw5Fug==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "^0.28.1"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "jsdom": "^26.1.0",
     "prettier": "^3.5.3",
     "typedoc": "^0.28.5",
+    "typedoc-plugin-missing-exports": "^4.0.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1",
     "vite": "^6.3.5",

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,5 +2,10 @@
 	"name": "@nosto/search-js",
 	"entryPoints": ["packages/*/*.ts"],
 	"out": "docs",
-	"highlightLanguages": ["typescript", "bash", "js", "jsx"]
+	"highlightLanguages": ["typescript", "bash", "js", "jsx"],
+	"excludeExternals": true,
+	"plugin": ["typedoc-plugin-missing-exports"],
+	"excludeReferences": true,
+	"placeInternalsInOwningModule": true,
+	"excludeInternal": true
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->

Typedoc now presents only top level exported types which makes it too hard to interpret and use the APIs offered by the library. This PR uses the `typedoc-plugin-missing-exports` and includes types referenced by the exported types in the documentation. 

Right now this approach works well but with a catch. The extracted type hierarchy gets included under a single module and the plugin don't respect the `@module` annotation. I will submit a ticket in the upstream repo on this. 

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->

### After
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/65cf2ebc-ec84-4f06-8541-b39cb678ffdc" />

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/4a422814-0186-4ed7-80a6-da263e9dd800" />

## Open issue
<img width="358" alt="image" src="https://github.com/user-attachments/assets/d6de2263-3fef-401b-bc39-e9cc5214ccd2" />
