### PR TITLE
fix!: onResult and onError moved to hook props

### DIFF
--- a/dev/preact/src/pages/Search/Content/Paginated.tsx
+++ b/dev/preact/src/pages/Search/Content/Paginated.tsx
@@ -8,7 +8,13 @@ import { Product } from "../Product"
 
 function SpeechToTextButton() {
   const { newSearch } = useActions()
-  const { startListening, listening, stopListening } = useSpeechToText()
+  const { startListening, listening, stopListening } = useSpeechToText({
+    onResult: value => {
+      newSearch({
+        query: value
+      })
+    }
+  })
 
   if (!speechToTextSupported) {
     return null
@@ -20,13 +26,7 @@ function SpeechToTextButton() {
         if (listening) {
           stopListening()
         } else {
-          startListening({
-            onResult: value => {
-              newSearch({
-                query: value
-              })
-            }
-          })
+          startListening()
         }
       }}
     >

--- a/packages/preact/test/hooks/useSpeechToText.spec.ts
+++ b/packages/preact/test/hooks/useSpeechToText.spec.ts
@@ -13,12 +13,16 @@ describe("useSpeechToText", async () => {
   })
 
   it("calls start and stop methods of SpeechRecognition", () => {
-    const { result } = renderHook(() => useSpeechToText())
+    const { result } = renderHook(() =>
+      useSpeechToText({
+        onResult: vi.fn()
+      })
+    )
 
     expect(startMock).not.toHaveBeenCalled()
     expect(stopMock).not.toHaveBeenCalled()
 
-    result.current.startListening({ onResult: vi.fn() })
+    result.current.startListening()
 
     expect(startMock).toHaveBeenCalled()
 


### PR DESCRIPTION
## Context

Cleaned up prop handlers that are passed trough startListening - moved them to hook props

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
