### PR TITLE
feat: infinite scroll improvements

### DIFF
--- a/dev/preact/src/pages/Search/Content/InfiniteScrolled.tsx
+++ b/dev/preact/src/pages/Search/Content/InfiniteScrolled.tsx
@@ -30,7 +30,7 @@ export function InfiniteScrolled() {
         Searching for: <b>{input}</b>
       </div>
       <div>Results: {hits.map(hit => hit.name).join(", ")}</div>
-      <InfiniteScroll pageSize={5}>
+      <InfiniteScroll rootMargin="100% 0px" pageSize={5}>
         {hits.map(hit => (
           <Product key={hit.productId} product={hit} />
         ))}

--- a/dev/preact/src/pages/Search/Content/InfiniteScrolled.tsx
+++ b/dev/preact/src/pages/Search/Content/InfiniteScrolled.tsx
@@ -18,7 +18,9 @@ export function InfiniteScrolled() {
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", width: "100%", gap: 16, marginTop: 16 }}>
+    <div
+      style={{ display: "flex", position: "relative", flexDirection: "column", width: "100%", gap: 16, marginTop: 16 }}
+    >
       <div>
         <div>Totally working search with infinite scrolling:</div>
         <div style={{ display: "flex", gap: 4, width: "100%", justifyContent: "center" }}>
@@ -30,7 +32,7 @@ export function InfiniteScrolled() {
         Searching for: <b>{input}</b>
       </div>
       <div>Results: {hits.map(hit => hit.name).join(", ")}</div>
-      <InfiniteScroll rootMargin="100% 0px" pageSize={5}>
+      <InfiniteScroll observerOptions={{ rootMargin: "100% 0" }} pageSize={5}>
         {hits.map(hit => (
           <Product key={hit.productId} product={hit} />
         ))}

--- a/packages/preact/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/packages/preact/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -16,17 +16,12 @@ export interface InfiniteScrollProps {
   loadMoreComponent?: ComponentType<{ pageSize?: number }>
   pageSize?: number
   /**
-   * The margin around the root element for the IntersectionObserver.
-   * This can be used to trigger the loading of more results before the user reaches the end of the page.
-   * @default "0px"
-   * @example "500px 0px" - this will trigger loading more results when the user is 500px away from the end of the page.
+   * Options for the IntersectionObserver.
+   * This can be used to adjust the root margin, threshold, etc.
+   * For example, to trigger the observer when the user scrolls to the bottom of the page, you can set `rootMargin: "100% 0"`.
+   * @default { rootMargin: "0px", threshold: 0 }
    */
-  rootMargin?: string
-  /**
-   * The root element for the IntersectionObserver.
-   * If not provided, the observer will use the viewport as the root.
-   */
-  rootContiner?: Element
+  observerOptions?: IntersectionObserverInit
 }
 
 /**

--- a/packages/preact/src/components/InfiniteScroll/InfiniteScroll.tsx
+++ b/packages/preact/src/components/InfiniteScroll/InfiniteScroll.tsx
@@ -15,6 +15,18 @@ export interface InfiniteScrollProps {
   children: ComponentChildren
   loadMoreComponent?: ComponentType<{ pageSize?: number }>
   pageSize?: number
+  /**
+   * The margin around the root element for the IntersectionObserver.
+   * This can be used to trigger the loading of more results before the user reaches the end of the page.
+   * @default "0px"
+   * @example "500px 0px" - this will trigger loading more results when the user is 500px away from the end of the page.
+   */
+  rootMargin?: string
+  /**
+   * The root element for the IntersectionObserver.
+   * If not provided, the observer will use the viewport as the root.
+   */
+  rootContiner?: Element
 }
 
 /**

--- a/packages/preact/src/components/InfiniteScroll/InfiniteScrollWithObserver.tsx
+++ b/packages/preact/src/components/InfiniteScroll/InfiniteScrollWithObserver.tsx
@@ -11,7 +11,12 @@ import { hasMoreResults } from "./utils"
  * Infinite scroll component that loads more results when user scrolls to the end of the page.
  * @group Components
  */
-export function InfiniteScrollWithObserver({ children, pageSize }: InfiniteScrollProps): JSX.Element {
+export function InfiniteScrollWithObserver({
+  children,
+  pageSize,
+  rootContiner,
+  rootMargin
+}: InfiniteScrollProps): JSX.Element {
   const endResultsRef = useRef<HTMLDivElement>(null)
   const { query, response } = useNostoAppState(state => pick(state, "query", "response"))
 
@@ -23,12 +28,18 @@ export function InfiniteScrollWithObserver({ children, pageSize }: InfiniteScrol
 
     if (hasMoreResults(query, response)) {
       loader = endResultsRef.current
-      observer = new IntersectionObserver(entries => {
-        const target = entries[0]
-        if (target?.isIntersecting) {
-          loadMore()
+      observer = new IntersectionObserver(
+        entries => {
+          const target = entries[0]
+          if (target?.isIntersecting) {
+            loadMore()
+          }
+        },
+        {
+          rootMargin,
+          root: rootContiner
         }
-      })
+      )
 
       if (loader) {
         observer.observe(loader)
@@ -41,7 +52,7 @@ export function InfiniteScrollWithObserver({ children, pageSize }: InfiniteScrol
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [response])
+  }, [response, rootMargin, rootContiner])
 
   return (
     <>

--- a/packages/preact/src/components/InfiniteScroll/InfiniteScrollWithObserver.tsx
+++ b/packages/preact/src/components/InfiniteScroll/InfiniteScrollWithObserver.tsx
@@ -14,8 +14,7 @@ import { hasMoreResults } from "./utils"
 export function InfiniteScrollWithObserver({
   children,
   pageSize,
-  rootContiner,
-  rootMargin
+  observerOptions = {}
 }: InfiniteScrollProps): JSX.Element {
   const endResultsRef = useRef<HTMLDivElement>(null)
   const { query, response } = useNostoAppState(state => pick(state, "query", "response"))
@@ -28,18 +27,12 @@ export function InfiniteScrollWithObserver({
 
     if (hasMoreResults(query, response)) {
       loader = endResultsRef.current
-      observer = new IntersectionObserver(
-        entries => {
-          const target = entries[0]
-          if (target?.isIntersecting) {
-            loadMore()
-          }
-        },
-        {
-          rootMargin,
-          root: rootContiner
+      observer = new IntersectionObserver(entries => {
+        const target = entries[0]
+        if (target?.isIntersecting) {
+          loadMore()
         }
-      )
+      }, observerOptions)
 
       if (loader) {
         observer.observe(loader)
@@ -52,7 +45,7 @@ export function InfiniteScrollWithObserver({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [response, rootMargin, rootContiner])
+  }, [response, observerOptions])
 
   return (
     <>


### PR DESCRIPTION
## Context

Improved by adding props for margin of the observer container. This way user can specify the margin on when the "registration" of visible marker happens

Alternative approach from https://github.com/Nosto/search-js/pull/251

## Related Jira ticket

https://nostosolutions.atlassian.net/browse/CFE-1124

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
