### PR TITLE
fix: default page size

### DIFF
--- a/packages/preact/src/hooks/useSizeOptions.ts
+++ b/packages/preact/src/hooks/useSizeOptions.ts
@@ -46,7 +46,7 @@ function normalize(value: number) {
 export function useSizeOptions(sizes: number[], serpSize: number) {
   const { from, size, total } = useNostoAppState(state => ({
     from: normalize(state.query.products?.from ?? 0),
-    size: normalize(state.response?.products?.size ?? 0),
+    size: normalize(state.response?.products?.size ?? serpSize),
     total: normalize(state.response?.products?.total ?? 0)
   }))
 

--- a/packages/preact/test/hooks/useSizeOptions.spec.ts
+++ b/packages/preact/test/hooks/useSizeOptions.spec.ts
@@ -36,6 +36,19 @@ describe("useSizeOptions", () => {
     expect(size).toBe(10)
   })
 
+  it("returns correct initial values if no request has been made yet", () => {
+    const sizes = [24, 48, 72]
+    const serpSize = 5
+
+    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: mockStore({}) })
+    const { from, to, total, size } = render.result.current
+
+    expect(from).toBe(0)
+    expect(to).toBe(5)
+    expect(total).toBe(0)
+    expect(size).toBe(5)
+  })
+
   it("handles size change correctly", () => {
     const sizes = [24, 48, 72]
     const serpSize = 5


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
`useSizeOptions()` currently reports size of 0 until a request has been made. It should actually return the default value provided.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
