### PR TITLE
feat: provide highlighted element index through context

### DIFF
--- a/dev/preact/src/components/Product/ProductRow.tsx
+++ b/dev/preact/src/components/Product/ProductRow.tsx
@@ -9,6 +9,7 @@ import { productImagePlaceholder } from "../../utils/productImagePlaceholder"
 
 type Props = {
   product: SearchProduct
+  highlighted: boolean
 }
 
 const styles = {
@@ -79,7 +80,7 @@ const styles = {
   }
 }
 
-export function ProductRow({ product: baseProduct }: Props) {
+export function ProductRow({ product: baseProduct, highlighted }: Props) {
   const product = useDecoratedSearchResults<typeof hitDecorators>(baseProduct)
   const { reportProductClick } = useContext(AutocompleteContext)
 
@@ -89,7 +90,7 @@ export function ProductRow({ product: baseProduct }: Props) {
         .product-row {
           transition: background-color 0.15s ease;
         }
-        .product-row:hover {
+        .product-row:hover, .product-row.highlighted {
           background-color: #f3f4f6 !important;
         }
       `}</style>
@@ -103,7 +104,7 @@ export function ProductRow({ product: baseProduct }: Props) {
         componentProps={{
           href: product.url,
           onClick: () => reportProductClick(product),
-          className: "product-row",
+          className: "product-row" + (highlighted ? " highlighted" : ""),
           style: styles.container,
           "aria-label": `Product ${product.name}`
         }}

--- a/dev/preact/src/pages/Autocomplete/components/AutocompleteHistory.tsx
+++ b/dev/preact/src/pages/Autocomplete/components/AutocompleteHistory.tsx
@@ -1,4 +1,6 @@
 import { useNostoAppState } from "@nosto/search-js/preact/hooks"
+import { AutocompleteContext } from "@nosto/search-js/preact/inject"
+import { useContext } from "preact/hooks"
 
 import { AutocompleteHistoryElement } from "./AutocompleteHistoryElement"
 
@@ -30,6 +32,7 @@ const styles = {
 
 export function AutocompleteHistory() {
   const historyItems = useNostoAppState(state => state.historyItems)
+  const { highlightedElementIndex } = useContext(AutocompleteContext)
 
   if (!historyItems) {
     return null
@@ -38,8 +41,8 @@ export function AutocompleteHistory() {
   return (
     <div style={styles.container}>
       <div style={styles.header}>Recent searches</div>
-      {historyItems.map(item => (
-        <AutocompleteHistoryElement key={item} item={item} />
+      {historyItems.map((item, index) => (
+        <AutocompleteHistoryElement key={item} item={item} highlighted={index === highlightedElementIndex} />
       ))}
     </div>
   )

--- a/dev/preact/src/pages/Autocomplete/components/AutocompleteHistoryElement.tsx
+++ b/dev/preact/src/pages/Autocomplete/components/AutocompleteHistoryElement.tsx
@@ -25,7 +25,7 @@ const styles = {
   }
 }
 
-export function AutocompleteHistoryElement({ item }: { item: string }) {
+export function AutocompleteHistoryElement({ item, highlighted }: { item: string; highlighted: boolean }) {
   const { handleSubmit } = useContext(AutocompleteContext)
 
   const onSubmit = () => {
@@ -34,7 +34,14 @@ export function AutocompleteHistoryElement({ item }: { item: string }) {
 
   return (
     <HistoryElement key={item} onSubmit={onSubmit}>
-      <div style={styles.container}>
+      <style>
+        {`
+          .history-element.highlighted, .history-element:hover {
+            background-color: #0c080811;
+          }
+        `}
+      </style>
+      <div style={styles.container} className={"history-element" + (highlighted ? " highlighted" : "")}>
         <div style={styles.name}>{item}</div>
       </div>
     </HistoryElement>

--- a/dev/preact/src/pages/Autocomplete/components/AutocompleteResults.tsx
+++ b/dev/preact/src/pages/Autocomplete/components/AutocompleteResults.tsx
@@ -1,4 +1,6 @@
 import { SearchKeyword, SearchProduct } from "@nosto/nosto-js/client"
+import { AutocompleteContext } from "@nosto/search-js/preact/inject"
+import { useContext } from "preact/hooks"
 
 import { ProductRow } from "../../../components/Product/ProductRow"
 import { AutocompleteKeyword } from "./AutocompleteKeyword"
@@ -14,6 +16,7 @@ export function AutocompleteResults({
   keywords: SearchKeyword[]
   initialized: boolean
 }) {
+  const { highlightedElementIndex } = useContext(AutocompleteContext)
   if (!initialized) {
     return <div>Start typing to search</div>
   }
@@ -27,8 +30,12 @@ export function AutocompleteResults({
       {keywords.map(keyword => (
         <AutocompleteKeyword key={keyword.keyword} keyword={keyword} />
       ))}
-      {hits.map(hit => (
-        <ProductRow key={hit.productId} product={hit} />
+      {hits.map((hit, index) => (
+        <ProductRow
+          key={hit.productId}
+          product={hit}
+          highlighted={index + keywords.length === highlightedElementIndex}
+        />
       ))}
     </div>
   )

--- a/dev/preact/src/style.css
+++ b/dev/preact/src/style.css
@@ -47,10 +47,6 @@ header a:hover {
 	background-color: #0008;
 }
 
-.ns-autocomplete-element:hover, .ns-autocomplete-element-hovered {
-	background-color: #00000011;
-}
-
 main {
 	flex: auto;
 	display: flex;

--- a/packages/preact/inject/src/init/autocomplete/AutocompleteContext.tsx
+++ b/packages/preact/inject/src/init/autocomplete/AutocompleteContext.tsx
@@ -20,20 +20,11 @@ export const AutocompleteContext = createContext<AutocompleteUserContext>({
   highlightedElementIndex: -1
 })
 
-export const createContextHandle = (
+export function createContextHandle(
   context: AutocompleteInjectContext,
   element: AutocompleteDropdown | AutocompleteHistory
-): AutocompleteUserContext => {
-  const eventHandlers = createEventHandlers(context)
-  return {
-    reportProductClick: eventHandlers.onReportProductClick,
-    reportKeywordClick: eventHandlers.onReportKeywordClick,
-    handleSubmit: eventHandlers.onHandleSubmit,
-    highlightedElementIndex: element.highlightedIndex()
-  }
-}
-
-function createEventHandlers({ dropdown, history, store, input, onNavigateToSearch }: AutocompleteInjectContext) {
+): AutocompleteUserContext {
+  const { dropdown, history, store, input, onNavigateToSearch } = context
   const onReportClick = (query: string, isKeyword: boolean) => {
     dropdown.hide()
     history.hide()
@@ -52,15 +43,16 @@ function createEventHandlers({ dropdown, history, store, input, onNavigateToSear
   }
 
   return {
-    onReportProductClick: (product: SearchProduct) => {
+    reportProductClick: (product: SearchProduct) => {
       onReportClick(product.name!, false)
     },
-    onReportKeywordClick: (keyword: SearchKeyword) => {
+    reportKeywordClick: (keyword: SearchKeyword) => {
       onReportClick(keyword.keyword, true)
     },
-    onHandleSubmit: (query: SearchQuery) => {
+    handleSubmit: (query: SearchQuery) => {
       onReportClick(query.query!, false)
       onNavigateToSearch?.(query)
-    }
+    },
+    highlightedElementIndex: element.highlightedIndex()
   }
 }

--- a/packages/preact/inject/src/init/autocomplete/AutocompleteContext.tsx
+++ b/packages/preact/inject/src/init/autocomplete/AutocompleteContext.tsx
@@ -1,12 +1,66 @@
+import { nostojs } from "@nosto/nosto-js"
 import { SearchKeyword, SearchProduct, SearchQuery } from "@nosto/nosto-js/client"
 import { createContext } from "preact"
 
-export const AutocompleteContext = createContext<{
+import { AutocompleteInjectContext } from "../injectAutocomplete"
+import { AutocompleteDropdown } from "./components/AutocompleteDropdown"
+import { AutocompleteHistory } from "./components/AutocompleteHistory"
+
+export type AutocompleteUserContext = {
   reportProductClick: (product: SearchProduct) => void
   reportKeywordClick: (keyword: SearchKeyword) => void
   handleSubmit: (query: SearchQuery) => void
-}>({
+  highlightedElementIndex: number
+}
+
+export const AutocompleteContext = createContext<AutocompleteUserContext>({
   reportProductClick: () => {},
   reportKeywordClick: () => {},
-  handleSubmit: () => {}
+  handleSubmit: () => {},
+  highlightedElementIndex: -1
 })
+
+export const createContextHandle = (
+  context: AutocompleteInjectContext,
+  element: AutocompleteDropdown | AutocompleteHistory
+): AutocompleteUserContext => {
+  const eventHandlers = createEventHandlers(context)
+  return {
+    reportProductClick: eventHandlers.onReportProductClick,
+    reportKeywordClick: eventHandlers.onReportKeywordClick,
+    handleSubmit: eventHandlers.onHandleSubmit,
+    highlightedElementIndex: element.highlightedIndex()
+  }
+}
+
+function createEventHandlers({ dropdown, history, store, input, onNavigateToSearch }: AutocompleteInjectContext) {
+  const onReportClick = (query: string, isKeyword: boolean) => {
+    dropdown.hide()
+    history.hide()
+    if (!query) {
+      return
+    }
+
+    history.add(query)
+    store.updateState({
+      historyItems: history.get()
+    })
+    if (isKeyword) {
+      nostojs(api => api.recordSearchSubmit(query))
+    }
+    input.value = query
+  }
+
+  return {
+    onReportProductClick: (product: SearchProduct) => {
+      onReportClick(product.name!, false)
+    },
+    onReportKeywordClick: (keyword: SearchKeyword) => {
+      onReportClick(keyword.keyword, true)
+    },
+    onHandleSubmit: (query: SearchQuery) => {
+      onReportClick(query.query!, false)
+      onNavigateToSearch?.(query)
+    }
+  }
+}

--- a/packages/preact/inject/src/init/autocomplete/components/AutocompleteHistory.tsx
+++ b/packages/preact/inject/src/init/autocomplete/components/AutocompleteHistory.tsx
@@ -10,6 +10,7 @@ export type AutocompleteHistory = ReturnType<typeof createHistoryComponent>
 export function createHistoryComponent(input: HTMLInputElement, dropdownSelector: CssSelector, historySize: number) {
   const dropdown = document.createElement("div")
   dropdown.className = "nosto-autocomplete-history"
+
   const base = createComponent(input, dropdown, dropdownSelector)
 
   return {

--- a/packages/preact/inject/src/init/autocomplete/events/onFocus.tsx
+++ b/packages/preact/inject/src/init/autocomplete/events/onFocus.tsx
@@ -9,7 +9,10 @@ export async function onFocus(value: string, context: AutocompleteInjectContext)
     return
   }
 
-  const userComponentRenderer = createUserComponentRenderer(context)
+  const userComponentRenderer = createUserComponentRenderer(context, history)
+  history.onHighlightChange(() => {
+    userComponentRenderer(renderHistory, history.element)
+  })
   history.show()
   const end = measure("renderHistory")
   userComponentRenderer(renderHistory, history.element)

--- a/packages/preact/inject/src/init/autocomplete/events/onKeyDown.tsx
+++ b/packages/preact/inject/src/init/autocomplete/events/onKeyDown.tsx
@@ -4,13 +4,13 @@ import { AutocompleteHistory } from "../components/AutocompleteHistory"
 
 export function onKeyDown(value: string, key: string, context: AutocompleteInjectContext) {
   const { config, debouncer } = context
-  if (value.length >= config.minQueryLength) {
-    elementControls(key, context.dropdown, context.history)
-  } else if (config.historyEnabled) {
-    elementControls(key, context.history, context.dropdown)
-  }
   // Cancel debounce
   debouncer(() => {})
+  if (value.length >= config.minQueryLength) {
+    return elementControls(key, context.dropdown, context.history)
+  } else if (config.historyEnabled) {
+    return elementControls(key, context.history, context.dropdown)
+  }
 }
 
 export function elementControls(
@@ -43,5 +43,6 @@ export function elementControls(
       activeElement.submitHighlightedItem(highlighted)
     }
     activeElement.hide()
+    return highlighted >= 0 // Key handled
   }
 }

--- a/packages/preact/inject/src/init/autocomplete/events/onSubmit.tsx
+++ b/packages/preact/inject/src/init/autocomplete/events/onSubmit.tsx
@@ -14,11 +14,7 @@ export function onSubmit(
   store.updateState({
     historyItems: history.get()
   })
-  const highlighted = dropdown.highlightedIndex()
-  if (highlighted >= 0) {
-    dropdown.submitHighlightedItem(highlighted)
-    return
-  }
+
   onNavigateToSearch?.({
     query: value
   })

--- a/packages/utils/src/bindInput.ts
+++ b/packages/utils/src/bindInput.ts
@@ -31,11 +31,11 @@ export function bindInput(
 
   if (onKeyDown || onSubmit) {
     addEventListener(target, "keydown", (event: KeyboardEvent) => {
-      onKeyDown?.(target.value, event.key)
+      const isKeyPressHandled = onKeyDown?.(target.value, event.key)
       if (onKeyDown && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
         event.preventDefault()
       } else if (onSubmit && event.key === "Enter") {
-        if (target.value !== "" && !event.repeat) {
+        if (target.value !== "" && !event.repeat && !isKeyPressHandled) {
           onSubmit(target.value)
         }
         if (!nativeSubmit) {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
Cleanup part 4 out of 3 🙃 

Instead of relying on classes to select the hovered element in autocomplete or history, use actual state object that is exposed to the user component through context. It's working in canonical way, triggering rerenders on user components as necessary.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
