### PR TITLE
fix: decouple getSaved from useHistory

### DIFF
--- a/packages/preact/autocomplete/src/AutocompletePageProvider.tsx
+++ b/packages/preact/autocomplete/src/AutocompletePageProvider.tsx
@@ -3,7 +3,7 @@ import { StoreActionsListener } from "@preact/common/store/components/StoreActio
 import { createStore, type Store } from "@preact/common/store/store"
 import { StoreContext } from "@preact/common/store/storeContext"
 import { useCheckClientScript } from "@preact/hooks/useCheckClientScript"
-import { useHistory } from "@preact/hooks/useHistory"
+import { getSaved } from "@preact/hooks/useHistory"
 import { ComponentChildren } from "preact"
 import { useEffect } from "preact/hooks"
 
@@ -19,13 +19,11 @@ export function AutocompletePageProvider({ config, store, children }: Autocomple
   const actualStore = store ?? createStore()
   useCheckClientScript()
 
-  const { getSaved } = useHistory()
-
   useEffect(() => {
     actualStore.updateState({
       historyItems: getSaved()
     })
-  }, [actualStore, getSaved])
+  }, [actualStore])
 
   return (
     <ConfigContext value={makeAutocompleteConfig(config)}>

--- a/packages/preact/hooks/src/useHistory.tsx
+++ b/packages/preact/hooks/src/useHistory.tsx
@@ -5,6 +5,14 @@ import { useCallback, useContext } from "preact/hooks"
 
 export const historyKey = "nosto:search-js:history"
 
+export function getSaved() {
+  const historyFromLocalStorage = getLocalStorageItem<string[]>(historyKey) ?? []
+  return historyFromLocalStorage
+    .slice()
+    .reverse()
+    .filter((c: string) => !!c)
+}
+
 export function useHistory() {
   const { updateState } = useContext(StoreContext)
   const { historySize } = useAutocompleteConfig()
@@ -20,16 +28,7 @@ export function useHistory() {
     [historySize, updateState]
   )
 
-  const getSaved = useCallback(() => {
-    const historyFromLocalStorage = getLocalStorageItem<string[]>(historyKey) ?? []
-    return historyFromLocalStorage
-      .slice()
-      .reverse()
-      .filter((c: string) => !!c)
-  }, [])
-
   return {
-    addQuery,
-    getSaved
+    addQuery
   }
 }

--- a/packages/preact/hooks/test/hooks/useHistory.spec.tsx
+++ b/packages/preact/hooks/test/hooks/useHistory.spec.tsx
@@ -1,6 +1,6 @@
 import { makeAutocompleteConfig } from "@preact/autocomplete/AutocompleteConfig"
 import { ConfigContext } from "@preact/common/config/configContext"
-import { historyKey, useHistory } from "@preact/hooks/useHistory"
+import { getSaved, historyKey, useHistory } from "@preact/hooks/useHistory"
 import { describe, expect, it, vi } from "vitest"
 
 import { mockLocalStorage, mockStore } from "../mocks/mocks"
@@ -66,27 +66,21 @@ describe("useHistory", () => {
 
   describe("getSaved", () => {
     it("should return empty array when no history exists", () => {
-      const { result } = renderUseHistory()
-
-      const saved = result.current.getSaved()
+      const saved = getSaved()
 
       expect(saved).toEqual([])
     })
 
     it("should return reversed history items", () => {
       localStorage.setItem(historyKey, JSON.stringify(["query1", "query2", "query3"]))
-      const { result } = renderUseHistory()
-
-      const saved = result.current.getSaved()
+      const saved = getSaved()
 
       expect(saved).toEqual(["query3", "query2", "query1"])
     })
 
     it("should filter out empty strings and falsy values", () => {
       localStorage.setItem(historyKey, JSON.stringify(["query1", "", "query2", null, "query3", undefined]))
-      const { result } = renderUseHistory()
-
-      const saved = result.current.getSaved()
+      const saved = getSaved()
 
       expect(saved).toEqual(["query3", "query2", "query1"])
     })


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
useHistory needs the autocomplete page context, so it can't be called from within the AutocompletePageProvider

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
