### PR TITLE
fix: add repositry config in package.json and pin semantic-version t0 25.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
         id: semantic
         with:
+          semantic_version: 25.0.2
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
@@ -56,7 +57,6 @@ jobs:
             ]
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
 
   publish-docs:
     needs: release

--- a/package.json
+++ b/package.json
@@ -128,5 +128,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nosto/search-js.git"
   }
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request introduces minor updates to the release workflow and metadata for the repository. The changes primarily focus on ensuring correct semantic release versioning and providing more complete repository information.

Release workflow improvements:
* Updated the `semantic_version` to `25.0.2` in the release workflow to ensure the correct version of semantic-release is used.
* Removed the `NPM_TOKEN` environment variable from the release workflow, which may help clarify token usage or avoid redundancy.

Repository metadata update:
* Added a `repository` field to `package.json` to specify the repository type and URL, improving package metadata and integration with package registries.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
