### PR TITLE
fix: repository.url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nosto/search-js.git"
+    "url": "git+https://github.com/Nosto/search-js.git"
   }
 }


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
This pull request includes a minor update to the `package.json` file, correcting the casing in the repository URL to use "Nosto" instead of "nosto".

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/CFE-1475

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
