### PR TITLE
[codex] docs: clarify SerpElement click tracking

### DIFF
--- a/packages/preact/serp/src/components/SerpElement.tsx
+++ b/packages/preact/serp/src/components/SerpElement.tsx
@@ -14,7 +14,9 @@ export type SerpElementProps<C extends AsComponent> = Omit<BaseElementProps<C>, 
 }
 
 /**
- * Wrapper component that can be used to wrap any element in the search result list.
+ * Wrapper component for rendering products in search result lists.
+ *
+ * Wrap product rendering with this component so product clicks are tracked.
  *
  * @group Components
  */


### PR DESCRIPTION
## What changed

Updated the SerpElement TypeDoc comment to state that product rendering should be wrapped with the component so product clicks are tracked.

## Why

The previous docs only described SerpElement as a generic search result wrapper, which did not make the click tracking requirement explicit.

## Validation

- npm run typedoc