### PR TITLE
[codex] remove npm audit workflow steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-      
       - name: Install dev app dependencies
         working-directory: ./dev/preact
         run: npm ci
-
-      - name: Audit dev app dependencies
-        working-directory: ./dev/preact
-        run: npm audit --audit-level=high
 
       - name: Run build
         run: npm run build
@@ -52,16 +45,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-      
       - name: Install dev app dependencies
         working-directory: ./dev/preact
         run: npm ci
-
-      - name: Audit dev app dependencies
-        working-directory: ./dev/preact
-        run: npm audit --audit-level=high
 
       - name: Run parent build
         run: npm run build
@@ -88,9 +74,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
 
       - name: Run lint
         run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,16 +33,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-
       - name: Install dev app dependencies
         working-directory: ./dev/preact
         run: npm ci
-
-      - name: Audit dev app dependencies
-        working-directory: ./dev/preact
-        run: npm audit --audit-level=high
 
       - name: Run build
         run: npm run build
@@ -91,16 +84,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=high
-  
       - name: Install dev app dependencies
         working-directory: ./dev/preact
         run: npm ci
-
-      - name: Audit dev app dependencies
-        working-directory: ./dev/preact
-        run: npm audit --audit-level=high
 
       - run: npm run build
 


### PR DESCRIPTION
## Summary

Removes `npm audit --audit-level=high` steps from the GitHub Actions CI and release workflows.

The install, build, test, lint, release, and docs publish steps remain unchanged.

## Validation

- Confirmed no remaining `npm audit`, `yarn npm audit`, `pnpm audit`, or generic `audit` references under `.github/workflows`
- Ran `git diff --check`