### PR TITLE
fix: useSizeOptions rounding up to the next size

### DIFF
--- a/dev/preact/src/components/Pagination.styles.ts
+++ b/dev/preact/src/components/Pagination.styles.ts
@@ -1,7 +1,49 @@
+const base = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minWidth: "36px",
+  height: "36px",
+  padding: "0 6px",
+  border: "1px solid #ddd",
+  borderRadius: "6px",
+  fontSize: "14px",
+  fontWeight: "500",
+  textDecoration: "none",
+  cursor: "pointer",
+  color: "#444",
+  lineHeight: 1,
+  transition: "background 0.15s, border-color 0.15s, color 0.15s",
+} as const
+
 export const styles = {
   container: {
     display: "flex",
-    gap: "10px",
-    justifyContent: "center"
-  }
+    gap: "4px",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: "24px 0",
+  },
+  link: base,
+  linkActive: {
+    ...base,
+    backgroundColor: "#673ab8",
+    borderColor: "#673ab8",
+    color: "#fff",
+  },
+  linkHover: {
+    ...base,
+    backgroundColor: "#f3f0f9",
+    borderColor: "#c4b5e8",
+  },
+  ellipsis: {
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "36px",
+    height: "36px",
+    fontSize: "14px",
+    color: "#aaa",
+    letterSpacing: "1px",
+  },
 }

--- a/dev/preact/src/components/Pagination.styles.ts
+++ b/dev/preact/src/components/Pagination.styles.ts
@@ -13,7 +13,7 @@ const base = {
   cursor: "pointer",
   color: "#444",
   lineHeight: 1,
-  transition: "background 0.15s, border-color 0.15s, color 0.15s",
+  transition: "background 0.15s, border-color 0.15s, color 0.15s"
 } as const
 
 export const styles = {
@@ -22,19 +22,19 @@ export const styles = {
     gap: "4px",
     justifyContent: "center",
     alignItems: "center",
-    padding: "24px 0",
+    padding: "24px 0"
   },
   link: base,
   linkActive: {
     ...base,
     backgroundColor: "#673ab8",
     borderColor: "#673ab8",
-    color: "#fff",
+    color: "#fff"
   },
   linkHover: {
     ...base,
     backgroundColor: "#f3f0f9",
-    borderColor: "#c4b5e8",
+    borderColor: "#c4b5e8"
   },
   ellipsis: {
     display: "inline-flex",
@@ -44,6 +44,6 @@ export const styles = {
     height: "36px",
     fontSize: "14px",
     color: "#aaa",
-    letterSpacing: "1px",
-  },
+    letterSpacing: "1px"
+  }
 }

--- a/dev/preact/src/components/Pagination.styles.ts
+++ b/dev/preact/src/components/Pagination.styles.ts
@@ -11,7 +11,7 @@ const base = {
   fontWeight: "500",
   textDecoration: "none",
   cursor: "pointer",
-  color: "#444",
+  color: "#ddd",
   lineHeight: 1,
   transition: "background 0.15s, border-color 0.15s, color 0.15s"
 } as const
@@ -34,7 +34,8 @@ export const styles = {
   linkHover: {
     ...base,
     backgroundColor: "#f3f0f9",
-    borderColor: "#c4b5e8"
+    borderColor: "#c4b5e8",
+    color: "#444"
   },
   ellipsis: {
     display: "inline-flex",

--- a/dev/preact/src/components/Pagination.tsx
+++ b/dev/preact/src/components/Pagination.tsx
@@ -1,13 +1,27 @@
 import { useActions, usePagination } from "@nosto/search-js/preact/hooks"
 import { type ComponentChildren } from "preact"
-import { useCallback } from "preact/hooks"
+import { useCallback, useState } from "preact/hooks"
 
 import { styles } from "./Pagination.styles"
 
-function PaginationLink({ goToPage, children }: { goToPage: () => void; children: ComponentChildren }) {
+function PaginationLink({
+  goToPage,
+  active,
+  children
+}: {
+  goToPage: () => void
+  active?: boolean
+  children: ComponentChildren
+}) {
+  const [hovered, setHovered] = useState(false)
+  const style = active ? styles.linkActive : hovered ? styles.linkHover : styles.link
+
   return (
     <a
       href="#"
+      style={style}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       onClick={e => {
         e.preventDefault()
         goToPage()
@@ -37,25 +51,25 @@ export function Pagination() {
 
   return (
     <div style={styles.container}>
-      {prev && <PaginationLink goToPage={handlePaginate(prev)}>{"<"}</PaginationLink>}
+      {prev && <PaginationLink goToPage={handlePaginate(prev)}>{"←"}</PaginationLink>}
       {first && (
         <>
           <PaginationLink goToPage={handlePaginate(first)}>{first.page}</PaginationLink>
-          <span>...</span>
+          <span style={styles.ellipsis}>{"···"}</span>
         </>
       )}
-      {pages.map(({ page, from }) => (
-        <PaginationLink key={page} goToPage={handlePaginate({ from })}>
+      {pages.map(({ page, from, current }) => (
+        <PaginationLink key={page} active={current} goToPage={handlePaginate({ from })}>
           {page}
         </PaginationLink>
       ))}
       {last && (
         <>
-          <span>...</span>
+          <span style={styles.ellipsis}>{"···"}</span>
           <PaginationLink goToPage={handlePaginate(last)}>{last.page}</PaginationLink>
         </>
       )}
-      {next && <PaginationLink goToPage={handlePaginate(next)}>{">"}</PaginationLink>}
+      {next && <PaginationLink goToPage={handlePaginate(next)}>{"→"}</PaginationLink>}
     </div>
   )
 }

--- a/dev/preact/src/components/Pagination.tsx
+++ b/dev/preact/src/components/Pagination.tsx
@@ -4,34 +4,6 @@ import { useCallback, useState } from "preact/hooks"
 
 import { styles } from "./Pagination.styles"
 
-function PaginationLink({
-  goToPage,
-  active,
-  children
-}: {
-  goToPage: () => void
-  active?: boolean
-  children: ComponentChildren
-}) {
-  const [hovered, setHovered] = useState(false)
-  const style = active ? styles.linkActive : hovered ? styles.linkHover : styles.link
-
-  return (
-    <a
-      href="#"
-      style={style}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      onClick={e => {
-        e.preventDefault()
-        goToPage()
-      }}
-    >
-      {children}
-    </a>
-  )
-}
-
 export function Pagination() {
   const { prev, first, pages, last, next } = usePagination({
     width: 5
@@ -71,5 +43,33 @@ export function Pagination() {
       )}
       {next && <PaginationLink goToPage={handlePaginate(next)}>{"→"}</PaginationLink>}
     </div>
+  )
+}
+
+function PaginationLink({
+  goToPage,
+  active,
+  children
+}: {
+  goToPage: () => void
+  active?: boolean
+  children: ComponentChildren
+}) {
+  const [hovered, setHovered] = useState(false)
+  const style = active ? styles.linkActive : hovered ? styles.linkHover : styles.link
+
+  return (
+    <a
+      href="#"
+      style={style}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onClick={e => {
+        e.preventDefault()
+        goToPage()
+      }}
+    >
+      {children}
+    </a>
   )
 }

--- a/dev/preact/src/components/SizeSelect.tsx
+++ b/dev/preact/src/components/SizeSelect.tsx
@@ -1,0 +1,26 @@
+import { useSizeOptions } from "@nosto/search-js/preact/hooks"
+
+import { defaultConfig, pageSizes } from "../defaultConfig"
+
+export function PageSizeSelect() {
+  const { size, sizeOptions, handleSizeChange } = useSizeOptions(pageSizes, defaultConfig.searchPageSize)
+
+  if (sizeOptions.length === 0) {
+    return null
+  }
+
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-end", margin: "12px" }}>
+      <label style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+        Show:
+        <select value={size} onChange={e => handleSizeChange(Number(e.currentTarget.value))}>
+          {sizeOptions.map(v => (
+            <option key={v} value={v}>
+              {v} items per page
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  )
+}

--- a/dev/preact/src/pages/Category/CategoryNative.tsx
+++ b/dev/preact/src/pages/Category/CategoryNative.tsx
@@ -21,7 +21,7 @@ export function CategoryNative() {
   } satisfies CategoryConfig
 
   return (
-    <div className="category" title="Category (Native)" style={styles.container}>
+    <div className="category" style={styles.container}>
       <CategoryPageProvider config={config}>
         <CategoryQueryHandler categoryPath={categoryPath} />
         {isInfiniteScrollEnabled ? <CategoryContentInfinite /> : <CategoryContentPaginated />}

--- a/dev/preact/src/pages/Category/components/CategoryContentPaginated.tsx
+++ b/dev/preact/src/pages/Category/components/CategoryContentPaginated.tsx
@@ -3,12 +3,14 @@ import { useNostoAppState } from "@nosto/search-js/preact/hooks"
 import { Pagination } from "../../../components/Pagination"
 import { ProductCard } from "../../../components/Product/ProductCard"
 import { ProductList } from "../../../components/Product/ProductList"
+import { PageSizeSelect } from "../../../components/SizeSelect"
 
 export function CategoryContentPaginated() {
   const { hits } = useNostoAppState(state => ({ hits: state.response.products?.hits || [] }))
 
   return (
     <>
+      <PageSizeSelect />
       <ProductList>
         {hits.map(hit => (
           <ProductCard key={hit.productId} product={hit} />

--- a/dev/preact/src/pages/Search/components/SearchContentPaginated.tsx
+++ b/dev/preact/src/pages/Search/components/SearchContentPaginated.tsx
@@ -3,12 +3,14 @@ import { useNostoAppState } from "@nosto/search-js/preact/hooks"
 import { Pagination } from "../../../components/Pagination"
 import { ProductCard } from "../../../components/Product/ProductCard"
 import { ProductList } from "../../../components/Product/ProductList"
+import { PageSizeSelect } from "../../../components/SizeSelect"
 
 export function SearchContentPaginated() {
   const { hits } = useNostoAppState(state => ({ hits: state.response.products?.hits || [] }))
 
   return (
     <>
+      <PageSizeSelect />
       <ProductList>
         {hits.map(hit => (
           <ProductCard key={hit.productId} product={hit} />

--- a/packages/preact/hooks/src/useSizeOptions.ts
+++ b/packages/preact/hooks/src/useSizeOptions.ts
@@ -55,7 +55,14 @@ export function useSizeOptions(sizes: number[], serpSize: number) {
 
   const to = from + size
 
-  const sizeOptions = useMemo(() => [...sizes].reverse().filter(value => value < total), [sizes, total])
+  const sizeOptions = useMemo(() => {
+    const sorted = [...sizes].sort((a, b) => a - b)
+    if (sorted.length === 0) {
+      return []
+    }
+    const ceiling = sorted.find(s => s >= total) ?? sorted[sorted.length - 1]
+    return sorted.filter(s => s <= ceiling).reverse()
+  }, [sizes, total])
 
   const handleSizeChange = useCallback(
     (size: number) => {

--- a/packages/preact/hooks/src/useSizeOptions.ts
+++ b/packages/preact/hooks/src/useSizeOptions.ts
@@ -56,10 +56,10 @@ export function useSizeOptions(sizes: number[], serpSize: number) {
   const to = from + size
 
   const sizeOptions = useMemo(() => {
-    const sorted = [...sizes].sort((a, b) => a - b)
-    if (sorted.length === 0) {
+    if (sizes.length === 0) {
       return []
     }
+    const sorted = [...sizes].sort((a, b) => a - b)
     const ceiling = sorted.find(s => s >= total) ?? sorted[sorted.length - 1]
     return sorted.filter(s => s <= ceiling).reverse()
   }, [sizes, total])

--- a/packages/preact/hooks/test/hooks/useSizeOptions.spec.ts
+++ b/packages/preact/hooks/test/hooks/useSizeOptions.spec.ts
@@ -79,25 +79,56 @@ describe("useSizeOptions", () => {
 
     expect(sizeOptions).toEqual([72, 48, 24])
   })
-  it("returns correct size options when there are no more results", () => {
+  it("returns minimal size option when there are no results", () => {
     const sizes = [24, 48, 72]
     const serpSize = 5
 
     const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(10) })
     const { sizeOptions } = render.result.current
 
-    expect(sizeOptions).toEqual([])
+    expect(sizeOptions).toEqual([24])
   })
 
-  it("returns only size options smaller than total", () => {
+  it("returns size options rounding up from total", () => {
     const sizes = [24, 48, 72]
     const serpSize = 5
 
-    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(50) })
+    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(32) })
     const { sizeOptions } = render.result.current
 
     expect(sizeOptions).toEqual([48, 24])
   })
+
+  it("returns minimal size options with few results", () => {
+    const sizes = [24, 48, 72]
+    const serpSize = 5
+
+    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(3) })
+    const { sizeOptions } = render.result.current
+
+    expect(sizeOptions).toEqual([24])
+  })
+
+  it("returns only size options less than or equal to total", () => {
+    const sizes = [24, 48, 72]
+    const serpSize = 5
+
+    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(48) })
+    const { sizeOptions } = render.result.current
+
+    expect(sizeOptions).toEqual([48, 24])
+  })
+
+  it("returns only size options equal to total", () => {
+    const sizes = [24, 48, 72]
+    const serpSize = 5
+
+    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(48) })
+    const { sizeOptions } = render.result.current
+
+    expect(sizeOptions).toEqual([48, 24])
+  })
+
   it("handles size change correctly with string passed instead", () => {
     const sizes = [24, 48, 72]
     const serpSize = 5

--- a/packages/preact/hooks/test/hooks/useSizeOptions.spec.ts
+++ b/packages/preact/hooks/test/hooks/useSizeOptions.spec.ts
@@ -79,11 +79,12 @@ describe("useSizeOptions", () => {
 
     expect(sizeOptions).toEqual([72, 48, 24])
   })
+
   it("returns minimal size option when there are no results", () => {
     const sizes = [24, 48, 72]
     const serpSize = 5
 
-    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(10) })
+    const render = renderHookWithProviders(() => useSizeOptions(sizes, serpSize), { store: createStoreWithTotal(0) })
     const { sizeOptions } = render.result.current
 
     expect(sizeOptions).toEqual([24])


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
The primary fix - the list of valid sizes for serp/category pages used to be defined as `less than total`, i.e. when the template defines page sizes as `[24, 48, 72]` and the total is 39, the page size selector would only show 24. Now, it will round up and show `[24, 48]`.

Also includes a change to the included dev app to render a page size selector.

> Note that all changes under `dev/preact` are part of the dev-only app that is not part of the shipped bundle. Essentially, it's a quick way to test if the changes actually work in the real app. You can pretty much ignore them.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/SEARCH-2276

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
<img width="1264" height="787" alt="image" src="https://github.com/user-attachments/assets/da56fe7e-2a82-4a5b-bca9-2bf397895ae2" />

