### PR TITLE
fix: tracking on cached requests

### DIFF
--- a/dev/preact/index.html
+++ b/dev/preact/index.html
@@ -5,7 +5,7 @@
 		<link rel="icon" type="image/svg+xml" href="/vite.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta name="color-scheme" content="light dark" />
-		<title>Vite + Preact</title>
+		<title>Search JS Dev App</title>
 	</head>
 	<body>
 		<div id="app"></div>

--- a/dev/preact/src/pages/Autocomplete/AutocompleteInjected.tsx
+++ b/dev/preact/src/pages/Autocomplete/AutocompleteInjected.tsx
@@ -15,7 +15,8 @@ export function AutocompleteInjected() {
     init({
       autocomplete: {
         config: {
-          defaultCurrency: "EUR"
+          defaultCurrency: "EUR",
+          memoryCache: true
         },
         formCssSelector: "#inject-autocomplete-form",
         inputCssSelector: "#inject-autocomplete-input",
@@ -41,7 +42,7 @@ export function AutocompleteInjected() {
           }
         }
       }
-    })
+    } satisfies Parameters<typeof init>[0])
   })
 
   const handleSearch = () => {

--- a/dev/preact/src/pages/Autocomplete/AutocompleteNative.tsx
+++ b/dev/preact/src/pages/Autocomplete/AutocompleteNative.tsx
@@ -6,6 +6,7 @@ import { AutocompleteSearchForm } from "./components/AutocompleteSearchForm"
 export function AutocompleteNative() {
   const config = {
     defaultCurrency: "EUR",
+    memoryCache: true,
     search: {
       hitDecorators
     }

--- a/dev/preact/src/pages/Category/CategoryInjected.tsx
+++ b/dev/preact/src/pages/Category/CategoryInjected.tsx
@@ -19,6 +19,7 @@ export function CategoryInject() {
       category: {
         config: {
           defaultCurrency: "EUR",
+          persistentSearchCache: true,
           search: {
             hitDecorators
           }

--- a/dev/preact/src/pages/Category/CategoryNative.tsx
+++ b/dev/preact/src/pages/Category/CategoryNative.tsx
@@ -15,6 +15,7 @@ export function CategoryNative() {
 
   const config = {
     defaultCurrency: "EUR",
+    persistentSearchCache: true,
     search: {
       hitDecorators
     }

--- a/dev/preact/src/pages/Search/SearchInjected.tsx
+++ b/dev/preact/src/pages/Search/SearchInjected.tsx
@@ -17,7 +17,8 @@ export function SearchInjected() {
     init({
       serp: {
         config: {
-          defaultCurrency: "EUR"
+          defaultCurrency: "EUR",
+          persistentSearchCache: true
         },
         cssSelector: "#inject-search",
         render: () => (

--- a/dev/preact/src/pages/Search/SearchNative.tsx
+++ b/dev/preact/src/pages/Search/SearchNative.tsx
@@ -15,6 +15,7 @@ export function SearchNative() {
 
   const config = {
     defaultCurrency: "EUR",
+    persistentSearchCache: true,
     search: {
       hitDecorators
     }

--- a/dev/preact/src/utils/initNosto.ts
+++ b/dev/preact/src/utils/initNosto.ts
@@ -2,7 +2,7 @@ import { getNostoWindow, init, isNostoLoaded, nostojs } from "@nosto/nosto-js"
 
 export function initNosto() {
   init({
-    merchantId: "shopify-10664366"
+    merchantId: "shopify-89653510460"
   })
   nostojs(api => api.setAutoLoad(false))
   const interval = setInterval(() => {

--- a/packages/core/src/withCache.ts
+++ b/packages/core/src/withCache.ts
@@ -1,4 +1,5 @@
 import { SearchFn, SearchOptions } from "@core/types"
+import { nostojs } from "@nosto/nosto-js"
 import { SearchQuery, SearchResult } from "@nosto/nosto-js/client"
 
 import { cacheSearchResult, loadCachedResult } from "./resultCaching"
@@ -32,12 +33,16 @@ async function getSearchResultWithCache(
 
   // when request data is already in cache
   if (size === resultSize) {
+    if (options.track) {
+      nostojs(api => api.recordSearch(options.track!, searchQuery, result))
+    }
+
     return result
   }
 
   // requested size is less than the cache size
   if (size < resultSize) {
-    return {
+    const trimmedResult = {
       ...result,
       products: {
         ...result.products,
@@ -45,7 +50,13 @@ async function getSearchResultWithCache(
         hits: cacheHits.slice(0, size),
         total: result.products?.total || 0
       }
+    } satisfies SearchResult
+
+    if (options.track) {
+      nostojs(api => api.recordSearch(options.track!, searchQuery, trimmedResult))
     }
+
+    return trimmedResult
   }
 
   // requested size is more than the cache size. So, use cache data for prefilling

--- a/packages/core/src/withMemoryCache.ts
+++ b/packages/core/src/withMemoryCache.ts
@@ -1,4 +1,5 @@
 import { SearchFn, SearchOptions } from "@core/types"
+import { nostojs } from "@nosto/nosto-js"
 import { SearchQuery, SearchResult } from "@nosto/nosto-js/client"
 import { isEqual } from "@utils/isEqual"
 
@@ -45,7 +46,13 @@ export async function searchWithMemoryCache(query: SearchQuery, options: SearchO
 
   const cacheKey = JSON.stringify(query)
   const cached = getFromCache(cacheKey, query)
-  if (cached) return cached
+  if (cached) {
+    if (options.track) {
+      nostojs(api => api.recordSearch(options.track!, query, cached))
+    }
+
+    return cached
+  }
 
   const result = await searchFn(query, options)
   setCache(cacheKey, query, result)

--- a/packages/core/test/search.withCache.spec.ts
+++ b/packages/core/test/search.withCache.spec.ts
@@ -1,11 +1,16 @@
 import { STORAGE_ENTRY_NAME } from "@core/resultCaching"
 import { searchWithCache } from "@core/withCache"
 import { SearchQuery, SearchResult } from "@nosto/nosto-js/client"
+import { mockNostojs } from "@nosto/nosto-js/testing"
 import { getSessionStorageItem } from "@utils/storage"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 describe("searchWithCache", () => {
   const search = vi.fn()
+
+  const mockNostojsApi = {
+    recordSearch: vi.fn()
+  }
 
   const resultDefault = { products: { hits: [{ name: "product 1" }], size: 1, total: 2 } }
 
@@ -16,13 +21,18 @@ describe("searchWithCache", () => {
   }
 
   async function testSearch({ query, result }: TestSearchOptions) {
-    const response = await searchWithCache(query, { usePersistentCache: true }, search)
+    const response = await searchWithCache(query, { usePersistentCache: true, track: "serp" }, search)
     expect(response).toEqual(result)
     expect(getSessionStorageItem(STORAGE_ENTRY_NAME)).toEqual({
       query,
       result,
       created: expect.any(Number)
     })
+  }
+
+  async function createCache({ ...options }: TestSearchOptions) {
+    await testSearch(options)
+    search.mockClear()
   }
 
   async function testSearchTriggered({ triggeredQuery, ...options }: TestSearchOptions) {
@@ -39,6 +49,7 @@ describe("searchWithCache", () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    mockNostojs(mockNostojsApi)
     search.mockResolvedValue(resultDefault)
 
     sessionStorage.clear()
@@ -56,6 +67,8 @@ describe("searchWithCache", () => {
         query: { products: { from: 1, size: 1 } },
         result: resultDefault
       })
+
+      expect(mockNostojsApi.recordSearch).not.toHaveBeenCalled()
     })
 
     it("should not call search when existing cache found, full page", async () => {
@@ -68,6 +81,16 @@ describe("searchWithCache", () => {
         query: { products: { from: 0, size: 1 } },
         result: resultDefault
       })
+    })
+
+    it("should call recordSearch when existing cache found, full page", async () => {
+      const query = { products: { from: 0, size: 1 } }
+
+      await createCache({ query, result: resultDefault })
+      mockNostojsApi.recordSearch.mockClear()
+      await testSearch({ query, result: resultDefault })
+
+      expect(mockNostojsApi.recordSearch).toHaveBeenCalledWith("serp", query, resultDefault)
     })
 
     it("should not call search when existing cache found, partial page", async () => {
@@ -89,6 +112,31 @@ describe("searchWithCache", () => {
         query: { products: { from: 0, size: 5 } },
         result: multipleResults
       })
+    })
+
+    it("should call recordSearch when existing cache found, full page", async () => {
+      const multipleResults = {
+        products: {
+          hits: [{ name: "product 1" }, { name: "product 2" }, { name: "product 3" }],
+          size: 5,
+          total: 3
+        }
+      }
+      search.mockResolvedValue(multipleResults)
+
+      const query = { products: { from: 0, size: 5 } }
+      await createCache({
+        query,
+        result: multipleResults
+      })
+
+      mockNostojsApi.recordSearch.mockClear()
+      await testSearchNotTriggered({
+        query,
+        result: multipleResults
+      })
+
+      expect(mockNostojsApi.recordSearch).toHaveBeenCalledWith("serp", query, multipleResults)
     })
 
     it("should call search when existing cache entry is expired", async () => {

--- a/packages/core/test/search.withCache.spec.ts
+++ b/packages/core/test/search.withCache.spec.ts
@@ -90,6 +90,7 @@ describe("searchWithCache", () => {
       mockNostojsApi.recordSearch.mockClear()
       await testSearch({ query, result: resultDefault })
 
+      expect(mockNostojsApi.recordSearch).toHaveBeenCalledTimes(1)
       expect(mockNostojsApi.recordSearch).toHaveBeenCalledWith("serp", query, resultDefault)
     })
 
@@ -114,7 +115,7 @@ describe("searchWithCache", () => {
       })
     })
 
-    it("should call recordSearch when existing cache found, full page", async () => {
+    it("should call recordSearch when existing cache found, partial page", async () => {
       const multipleResults = {
         products: {
           hits: [{ name: "product 1" }, { name: "product 2" }, { name: "product 3" }],
@@ -136,6 +137,7 @@ describe("searchWithCache", () => {
         result: multipleResults
       })
 
+      expect(mockNostojsApi.recordSearch).toHaveBeenCalledTimes(1)
       expect(mockNostojsApi.recordSearch).toHaveBeenCalledWith("serp", query, multipleResults)
     })
 

--- a/packages/core/test/searchWithMemoryCache.spec.ts
+++ b/packages/core/test/searchWithMemoryCache.spec.ts
@@ -47,6 +47,7 @@ describe("searchWithMemoryCache", () => {
   it("should call recordSearch if using cached response", async () => {
     await searchWithMemoryCache(query, { useMemoryCache: true, track: "serp" }, search)
     const response = await searchWithMemoryCache(query, { useMemoryCache: true, track: "serp" }, search)
+    expect(mockNostojsApi.recordSearch).toHaveBeenCalledTimes(1)
     expect(mockNostojsApi.recordSearch).toHaveBeenCalledWith("serp", query, response)
   })
 

--- a/packages/core/test/searchWithMemoryCache.spec.ts
+++ b/packages/core/test/searchWithMemoryCache.spec.ts
@@ -1,5 +1,6 @@
 import { clearMemoryCache, searchWithMemoryCache } from "@core/withMemoryCache"
 import { SearchQuery } from "@nosto/nosto-js/client"
+import { mockNostojs } from "@nosto/nosto-js/testing"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 describe("searchWithMemoryCache", () => {
@@ -15,10 +16,22 @@ describe("searchWithMemoryCache", () => {
     }
   }
 
+  const mockNostojsApi = {
+    recordSearch: vi.fn()
+  }
+
   beforeEach(() => {
     vi.resetAllMocks()
     search.mockResolvedValue(result)
+    mockNostojs(mockNostojsApi)
     clearMemoryCache()
+  })
+
+  it("should call search if useMemoryCache is true, but cache is empty", async () => {
+    const response = await searchWithMemoryCache(query, { useMemoryCache: true, track: "serp" }, search)
+    expect(response).toEqual(result)
+    expect(search).toHaveBeenCalledTimes(1)
+    expect(mockNostojsApi.recordSearch).not.toHaveBeenCalled()
   })
 
   it("should cache and reuse response if useMemoryCache is true", async () => {
@@ -29,6 +42,17 @@ describe("searchWithMemoryCache", () => {
     const cached = await searchWithMemoryCache(query, { useMemoryCache: true }, search)
     expect(cached).toEqual(result)
     expect(search).toHaveBeenCalledTimes(1)
+  })
+
+  it("should call recordSearch if using cached response", async () => {
+    await searchWithMemoryCache(query, { useMemoryCache: true, track: "serp" }, search)
+    const response = await searchWithMemoryCache(query, { useMemoryCache: true, track: "serp" }, search)
+    expect(mockNostojsApi.recordSearch).toHaveBeenCalledWith("serp", query, response)
+  })
+
+  it("should not call recordSearch if useMemoryCache is false", async () => {
+    await searchWithMemoryCache(query, { useMemoryCache: false, track: "serp" }, search)
+    expect(mockNostojsApi.recordSearch).not.toHaveBeenCalled()
   })
 
   it("should not cache if useMemoryCache is false", async () => {


### PR DESCRIPTION
## Context

<!-- One or two descriptive sentences about context and reason behind the PR is enough. -->
A merchant has noticed an issue with tracking requests not being sent when the caching mechanisms are enabled. With this PR, tracking requests are explicitly sent when cache is hit, avoiding missed impressions.

## Related Jira ticket

<!-- If applicable, share the link to and update the status of the ticket. -->
https://nostosolutions.atlassian.net/browse/NS-14145
https://nostosolutions.atlassian.net/browse/SEARCH-2302

## Screenshots

<!-- If there is a visual element to the PR please share screenshots -->
<!-- Remember the saying "one picture says the same as a 1000 words". -->
